### PR TITLE
Add workout creation and listing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Ask your AI assistant questions like:
 - "What was my HRV trend over the last 4 weeks?"
 - "Show me my resting heart rate and training load for last week"
 - "How many steps did I average per day this month?"
+- "List my rides from last month"
+- "Show me the details of my last long ride"
+- "Create a 90-minute sweet spot workout for me"
 
 ## Features
 
@@ -19,6 +22,10 @@ Ask your AI assistant questions like:
 | `authenticate_coros` | Log in with email and password — token stored securely in keyring |
 | `check_coros_auth` | Check whether a valid auth token is present |
 | `get_daily_metrics` | Fetch daily metrics (HRV, resting HR, training load, VO2max, stamina, and more) for n weeks (default: 4) |
+| `list_activities` | List activities for a date range with summary metrics |
+| `get_activity_detail` | Fetch full detail for a single activity (laps, HR zones, power zones) |
+| `list_workouts` | List all saved structured workout programs |
+| `create_workout` | Create a new structured workout with named steps and power targets |
 
 ---
 
@@ -140,6 +147,64 @@ Each record includes:
 | `ltsp` | analyse (merge) | Lactate threshold pace (s/km) |
 | `stamina_level` | analyse (merge) | Base fitness level |
 | `stamina_level_7d` | analyse (merge) | 7-day fitness trend |
+
+### `list_activities`
+
+List activities for a date range.
+
+```json
+{ "start_day": "20260101", "end_day": "20260305", "page": 1, "size": 30 }
+```
+
+Returns: `activities` (list), `total_count`, `page`
+
+Each activity includes: `activity_id`, `name`, `sport_type`, `sport_name`, `start_time`, `end_time`, `duration_seconds`, `distance_meters`, `avg_hr`, `max_hr`, `calories`, `training_load`, `avg_power`, `normalized_power`, `elevation_gain`
+
+### `get_activity_detail`
+
+Fetch full detail for a single activity. Requires the `sport_type` from `list_activities`.
+
+```json
+{ "activity_id": "469901014965714948", "sport_type": 200 }
+```
+
+Returns full activity data including laps, HR zones, power zones, and all sport-specific metrics.
+
+> **Note:** Large time-series arrays (`graphList`, `frequencyList`, `gpsLightDuration`) are stripped from the response to keep it manageable.
+
+### `list_workouts`
+
+List all saved structured workout programs.
+
+```json
+{}
+```
+
+Returns: `workouts` (list), `count`
+
+Each workout includes: `id`, `name`, `sport_type`, `sport_name`, `estimated_time_seconds`, `exercise_count`, `exercises` (list of steps with `name`, `duration_seconds`, `power_low_w`, `power_high_w`)
+
+### `create_workout`
+
+Create a new structured workout. Workouts appear in the Coros app and can be synced to the watch.
+
+```json
+{
+  "name": "Sweet Spot 90min",
+  "sport_type": 2,
+  "steps": [
+    {"name": "15:00 Einfahren",  "duration_minutes": 15, "power_low_w": 148, "power_high_w": 192},
+    {"name": "20:00 Sweet Spot", "duration_minutes": 20, "power_low_w": 260, "power_high_w": 275},
+    {"name": "5:00 Pause",       "duration_minutes":  5, "power_low_w": 100, "power_high_w": 150},
+    {"name": "20:00 Sweet Spot", "duration_minutes": 20, "power_low_w": 260, "power_high_w": 275},
+    {"name": "30:00 Ausfahren",  "duration_minutes": 30, "power_low_w": 100, "power_high_w": 192}
+  ]
+}
+```
+
+`sport_type`: `2` = Indoor Cycling (default), `200` = Road Bike
+
+Returns: `workout_id`, `name`, `total_minutes`, `steps_count`, `message`
 
 ---
 

--- a/coros_api.py
+++ b/coros_api.py
@@ -15,7 +15,7 @@ from typing import Optional
 import httpx
 
 from auth.storage import get_token, store_token
-from models import DailyRecord, HRVRecord, SleepPhases, SleepRecord, StoredAuth
+from models import ActivitySummary, DailyRecord, HRVRecord, SleepPhases, SleepRecord, StoredAuth
 
 # ---------------------------------------------------------------------------
 # Endpoint constants
@@ -27,6 +27,9 @@ ENDPOINTS = {
     "analyse": "/analyse/query",            # summary + t7dayList (28 days, has VO2max/fitness)
     "analyse_detail": "/analyse/dayDetail/query",  # daily metrics with date range (up to 24 weeks)
     "sleep": "/sleep/query",                # NOT available on Training Hub API
+    "activity_list": "/activity/query",
+    "activity_detail": "/activity/detail/query",
+    "sport_types": "/activity/fit/getImportSportList",
 }
 
 # Login works on teamapi.coros.com but tokens are only valid on the
@@ -249,6 +252,103 @@ async def fetch_daily_records(
                 rec.stamina_level_7d = item.get("staminaLevel7d") or rec.stamina_level_7d
 
     return sorted(records_by_date.values(), key=lambda r: r.date)
+
+
+# ---------------------------------------------------------------------------
+# Activity data
+# ---------------------------------------------------------------------------
+
+SPORT_NAMES: dict[int, str] = {
+    100: "Running", 102: "Trail Running", 103: "Track Running", 104: "Hiking",
+    200: "Road Bike", 201: "Indoor Cycling", 203: "Gravel Bike", 204: "MTB",
+    400: "Cardio", 402: "Strength", 403: "Yoga",
+    900: "Walking", 9807: "Bike Commute",
+}
+
+
+def _parse_activity(item: dict) -> ActivitySummary:
+    sport_type = item.get("sportType")
+    return ActivitySummary(
+        activity_id=str(item.get("labelId", "")),
+        name=item.get("name") or item.get("remark"),
+        sport_type=sport_type,
+        sport_name=SPORT_NAMES.get(sport_type, f"Sport {sport_type}") if sport_type else None,
+        start_time=str(item.get("startTime", "")) or None,
+        end_time=str(item.get("endTime", "")) or None,
+        duration_seconds=item.get("totalTime"),
+        distance_meters=item.get("totalDistance"),
+        avg_hr=item.get("avgHr"),
+        max_hr=item.get("maxHr"),
+        calories=item.get("calorie") or item.get("totalCalorie"),
+        training_load=item.get("trainingLoad"),
+        avg_power=item.get("avgPower"),
+        normalized_power=item.get("np"),
+        elevation_gain=item.get("totalAscent") or item.get("elevationGain"),
+    )
+
+
+async def fetch_activities(
+    auth: StoredAuth,
+    start_day: str,
+    end_day: str,
+    page: int = 1,
+    size: int = 30,
+    mode_list: Optional[list[int]] = None,
+) -> tuple[list[ActivitySummary], int]:
+    """
+    Fetch activity list for a date range.
+    Returns (activities, total_count).
+    """
+    params: dict = {
+        "startDay": start_day,
+        "endDay": end_day,
+        "pageNumber": page,
+        "size": size,
+    }
+    if mode_list:
+        params["modeList"] = ",".join(str(m) for m in mode_list)
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.get(
+            _base_url(auth.region) + ENDPOINTS["activity_list"],
+            params=params,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    if body.get("result") != "0000":
+        raise ValueError(f"Coros activity API error: {body.get('message', 'unknown error')}")
+
+    data = body.get("data", {})
+    items = data.get("dataList", data.get("list", []))
+    total = data.get("totalCount", len(items))
+    return [_parse_activity(i) for i in items], total
+
+
+async def fetch_activity_detail(auth: StoredAuth, activity_id: str, sport_type: int = 0) -> dict:
+    """
+    Fetch full activity detail including laps, HR zones, and metrics.
+    Returns raw API data dict.
+    Requires sport_type (e.g. 200=Road Bike, 201=Indoor Cycling, 100=Running).
+    """
+    headers = {k: v for k, v in _auth_headers(auth).items() if k != "Content-Type"}
+    url = _base_url(auth.region) + ENDPOINTS["activity_detail"]
+    form_data = {"labelId": activity_id, "userId": auth.user_id, "sportType": str(sport_type)}
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(url, data=form_data, headers=headers)
+        resp.raise_for_status()
+        body = resp.json()
+
+    if body.get("result") != "0000":
+        raise ValueError(f"Coros activity detail API error: {body.get('message', 'unknown error')}")
+
+    data = body.get("data", {})
+    # Strip large time-series arrays that bloat the response
+    for key in ("graphList", "frequencyList", "gpsLightDuration"):
+        data.pop(key, None)
+    return data
 
 
 # ---------------------------------------------------------------------------

--- a/coros_api.py
+++ b/coros_api.py
@@ -30,6 +30,8 @@ ENDPOINTS = {
     "activity_list": "/activity/query",
     "activity_detail": "/activity/detail/query",
     "sport_types": "/activity/fit/getImportSportList",
+    "workout_list": "/training/program/query",  # POST — list/fetch workout programs
+    "workout_add": "/training/program/add",     # POST — create new structured workout
 }
 
 # Login works on teamapi.coros.com but tokens are only valid on the
@@ -349,6 +351,123 @@ async def fetch_activity_detail(auth: StoredAuth, activity_id: str, sport_type: 
     for key in ("graphList", "frequencyList", "gpsLightDuration"):
         data.pop(key, None)
     return data
+
+
+# ---------------------------------------------------------------------------
+# Workout programs  (/training/program/query + /training/program/add)
+# ---------------------------------------------------------------------------
+
+# sportType=2 = Indoor Cycling (Rollen); intensityType=6 = power in watts
+# targetType=2 = time-based (seconds); exerciseType=2 = cycling block
+
+WORKOUT_SPORT_NAMES: dict[int, str] = {
+    2: "Indoor Cycling",
+    4: "Strength",
+    100: "Running",
+    200: "Road Bike",
+    201: "Indoor Cycling (alt)",
+}
+
+
+def _parse_workout(item: dict) -> dict:
+    exercises = []
+    for ex in item.get("exercises", []):
+        exercises.append({
+            "name": ex.get("name"),
+            "duration_seconds": ex.get("targetValue"),
+            "power_low_w": ex.get("intensityValue"),
+            "power_high_w": ex.get("intensityValueExtend"),
+            "sets": ex.get("sets", 1),
+        })
+    sport = item.get("sportType")
+    return {
+        "id": str(item.get("id", "")),
+        "name": item.get("name"),
+        "sport_type": sport,
+        "sport_name": WORKOUT_SPORT_NAMES.get(sport, f"Sport {sport}"),
+        "estimated_time_seconds": item.get("estimatedTime"),
+        "exercise_count": item.get("exerciseNum", len(exercises)),
+        "exercises": exercises,
+    }
+
+
+async def fetch_workouts(auth: StoredAuth) -> list[dict]:
+    """List all user workout programs."""
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["workout_list"],
+            json={},
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    if body.get("result") != "0000":
+        raise ValueError(f"Coros workout API error: {body.get('message', 'unknown error')}")
+
+    return [_parse_workout(w) for w in body.get("data", [])]
+
+
+async def create_workout(
+    auth: StoredAuth,
+    name: str,
+    steps: list[dict],
+    sport_type: int = 2,
+) -> str:
+    """
+    Create a new structured workout program.
+
+    steps: list of dicts with keys:
+      - name: str — step label (e.g. "10:00 Einfahren")
+      - duration_minutes: float — step duration in minutes
+      - power_low_w: int — lower power target in watts
+      - power_high_w: int — upper power target in watts (0 = open-ended)
+
+    Returns the new workout ID.
+    """
+    exercises = []
+    for i, step in enumerate(steps):
+        duration_s = int(step["duration_minutes"] * 60)
+        exercises.append({
+            "name": step["name"],
+            "exerciseType": 2,
+            "sportType": sport_type,
+            "intensityType": 6,           # power in watts
+            "intensityValue": step["power_low_w"],
+            "intensityValueExtend": step.get("power_high_w", 0),
+            "targetType": 2,              # time-based
+            "targetValue": duration_s,
+            "sets": 1,
+            "sortNo": 16777216 * (i + 1),
+            "restType": 3,
+            "restValue": 0,
+            "groupId": "0",
+            "isGroup": False,
+            "originId": "0",
+        })
+
+    total_seconds = sum(int(s["duration_minutes"] * 60) for s in steps)
+    payload = {
+        "name": name,
+        "sportType": sport_type,
+        "estimatedTime": total_seconds,
+        "access": 1,
+        "exercises": exercises,
+    }
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["workout_add"],
+            json=payload,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    if body.get("result") != "0000":
+        raise ValueError(f"Coros workout create error: {body.get('message', 'unknown error')}")
+
+    return str(body.get("data", ""))
 
 
 # ---------------------------------------------------------------------------

--- a/models.py
+++ b/models.py
@@ -47,6 +47,24 @@ class DailyRecord(BaseModel):
     stamina_level_7d: Optional[float] = None       # 7-day fitness trend
 
 
+class ActivitySummary(BaseModel):
+    activity_id: str
+    name: Optional[str] = None
+    sport_type: Optional[int] = None
+    sport_name: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    duration_seconds: Optional[int] = None
+    distance_meters: Optional[float] = None
+    avg_hr: Optional[int] = None
+    max_hr: Optional[int] = None
+    calories: Optional[int] = None
+    training_load: Optional[int] = None
+    avg_power: Optional[int] = None
+    normalized_power: Optional[int] = None
+    elevation_gain: Optional[int] = None
+
+
 class StoredAuth(BaseModel):
     access_token: str
     user_id: str

--- a/server.py
+++ b/server.py
@@ -164,6 +164,83 @@ async def get_daily_metrics(weeks: int = 4) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool: list_activities
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def list_activities(
+    start_day: str,
+    end_day: str,
+    page: int = 1,
+    size: int = 30,
+) -> dict:
+    """
+    List Coros activities for a date range.
+
+    Parameters
+    ----------
+    start_day : str
+        Start date in YYYYMMDD format.
+    end_day : str
+        End date in YYYYMMDD format.
+    page : int
+        Page number (default 1).
+    size : int
+        Results per page (default 30, max 100).
+
+    Returns
+    -------
+    dict with keys: activities (list), total_count, page
+    Each activity contains: activity_id, name, sport_type, sport_name,
+    start_time, end_time, duration_seconds, distance_meters, avg_hr, max_hr,
+    calories, training_load, avg_power, normalized_power, elevation_gain
+    """
+    auth = coros_api.get_stored_auth()
+    if auth is None:
+        return {"error": "Not authenticated.", "activities": []}
+    try:
+        activities, total = await coros_api.fetch_activities(auth, start_day, end_day, page, size)
+        return {
+            "activities": [a.model_dump() for a in activities],
+            "total_count": total,
+            "page": page,
+        }
+    except Exception as exc:
+        return {"error": str(exc), "activities": []}
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_activity_detail
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def get_activity_detail(activity_id: str, sport_type: int = 0) -> dict:
+    """
+    Fetch full detail for a single Coros activity.
+
+    Parameters
+    ----------
+    activity_id : str
+        The activity ID (labelId) from list_activities.
+    sport_type : int
+        Sport type ID from list_activities (e.g. 200=Road Bike, 201=Indoor Cycling,
+        100=Running). Required for the API call to succeed.
+
+    Returns
+    -------
+    dict with full activity data including laps, HR zones, power metrics,
+    elevation, and all available sport-specific fields.
+    """
+    auth = coros_api.get_stored_auth()
+    if auth is None:
+        return {"error": "Not authenticated."}
+    try:
+        return await coros_api.fetch_activity_detail(auth, activity_id, sport_type)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 

--- a/server.py
+++ b/server.py
@@ -241,6 +241,89 @@ async def get_activity_detail(activity_id: str, sport_type: int = 0) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool: list_workouts
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def list_workouts() -> dict:
+    """
+    List all saved workout programs in the Coros account.
+
+    Returns
+    -------
+    dict with keys: workouts (list), count
+    Each workout contains: id, name, sport_type, sport_name,
+    estimated_time_seconds, exercise_count, exercises (list of steps with
+    name, duration_seconds, power_low_w, power_high_w)
+    """
+    auth = coros_api.get_stored_auth()
+    if auth is None:
+        return {"error": "Not authenticated.", "workouts": []}
+    try:
+        workouts = await coros_api.fetch_workouts(auth)
+        return {"workouts": workouts, "count": len(workouts)}
+    except Exception as exc:
+        return {"error": str(exc), "workouts": []}
+
+
+# ---------------------------------------------------------------------------
+# Tool: create_workout
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def create_workout(
+    name: str,
+    steps: list[dict],
+    sport_type: int = 2,
+) -> dict:
+    """
+    Create a new structured workout in the Coros account.
+
+    The workout appears in the Coros app under Workouts and can be synced
+    to the watch for guided execution.
+
+    Parameters
+    ----------
+    name : str
+        Workout name (e.g. "Z2 Erholung 60min").
+    steps : list[dict]
+        List of workout steps. Each step must have:
+          - name (str): step label, e.g. "10:00 Einfahren"
+          - duration_minutes (float): step duration in minutes
+          - power_low_w (int): lower power target in watts
+          - power_high_w (int): upper power target in watts
+        Example:
+          [
+            {"name": "Einfahren", "duration_minutes": 10, "power_low_w": 148, "power_high_w": 192},
+            {"name": "Z2 Block", "duration_minutes": 40, "power_low_w": 192, "power_high_w": 221},
+            {"name": "Ausfahren", "duration_minutes": 10, "power_low_w": 100, "power_high_w": 165},
+          ]
+    sport_type : int
+        Sport type ID. Default 2 = Indoor Cycling (Rollen).
+        Use 200 for Road Bike (outdoor), 201 for Indoor Cycling (alt).
+
+    Returns
+    -------
+    dict with keys: workout_id, name, total_minutes, steps_count, message
+    """
+    auth = coros_api.get_stored_auth()
+    if auth is None:
+        return {"error": "Not authenticated."}
+    try:
+        workout_id = await coros_api.create_workout(auth, name, steps, sport_type)
+        total_minutes = sum(s["duration_minutes"] for s in steps)
+        return {
+            "workout_id": workout_id,
+            "name": name,
+            "total_minutes": total_minutes,
+            "steps_count": len(steps),
+            "message": "Workout created. Open Coros app → Workouts to sync to watch.",
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **`create_workout`**: Creates structured workout programs via the newly discovered `/training/program/add` endpoint. Supports named steps with power targets (watts) and durations. Workouts appear in the Coros app under Workouts and sync to the watch.
- **`list_workouts`**: Lists all saved workout programs via `/training/program/query` (POST), returning step details including power ranges.

## API Discovery

- `/training/program/query` (POST) — lists user workout programs
- `/training/program/add` (POST) — creates structured workouts
- `sportType=2` = Indoor Cycling, `intensityType=6` = power in watts, `targetType=2` = time-based

## Test plan

- [ ] `list_workouts` returns existing workouts with steps
- [ ] `create_workout` with multiple steps creates a workout visible in the Coros app
- [ ] Workout syncs to Coros watch via the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)