### PR TITLE
fix: skip mobile login during normal auth to avoid app logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Run the following command in your terminal — **outside** of any Claude session
 coros-mcp auth
 ```
 
-You will be prompted for your email, password, and region (`eu`, `us`, or `asia`). This stores both the Training Hub web token and the mobile API token used for sleep data. Your credentials are sent directly to Coros and the token is stored securely in your system keyring (or an encrypted local file as fallback). **You only need to do this once** — the token persists across restarts.
+You will be prompted for your email, password, and region (`eu`, `us`, or `asia`). This stores the Training Hub web token. Your credentials are sent directly to Coros and the token is stored securely in your system keyring (or an encrypted local file as fallback). **You only need to do this once** — the token persists across restarts.
+
+> **Note:** `coros-mcp auth` does **not** obtain a mobile API token (used for sleep data), because the mobile login invalidates any existing mobile app session on your phone. The mobile token is obtained automatically when you first request sleep data, or you can run `coros-mcp auth-mobile` manually.
 
 **Other auth commands:**
 
@@ -196,7 +198,7 @@ Each record includes:
 | `max_hr` | Maximum heart rate during sleep |
 | `quality_score` | Sleep quality score (null if not computed) |
 
-> **Note:** Sleep data is fetched from the Coros mobile API (`apieu.coros.com`), which uses a separate token from the Training Hub web API. **No extra setup required** — `coros-mcp auth` obtains both tokens automatically using credentials encrypted with the same key as the official Coros app. The token expires after ~1 hour but **refreshes automatically** in the background.
+> **Note:** Sleep data is fetched from the Coros mobile API (`apieu.coros.com`), which uses a separate token from the Training Hub web API. The mobile token is **not** obtained during `coros-mcp auth` to avoid logging you out of the Coros mobile app. Instead, it is obtained automatically when you first request sleep data (which will log you out of the app). The token expires after ~1 hour but **refreshes automatically** on subsequent requests.
 
 ### `list_activities`
 

--- a/coros_api.py
+++ b/coros_api.py
@@ -1049,7 +1049,8 @@ async def fetch_sleep(auth: StoredAuth, start_day: str, end_day: str) -> list[Sl
     if not auth.mobile_access_token:
         if not await _refresh_mobile_token(auth):
             raise ValueError(
-                "No mobile API token available. Run 'coros-mcp auth' to re-authenticate."
+                "No mobile API token available. Call authenticate_coros_mobile to get one. "
+                "Note: this will log you out of the Coros mobile app."
             )
 
     mobile_base = MOBILE_BASE_URLS.get(auth.region, MOBILE_BASE_URLS["eu"])
@@ -1076,7 +1077,7 @@ async def fetch_sleep(auth: StoredAuth, start_day: str, end_day: str) -> list[Sl
 
     body = await _do_request(auth.mobile_access_token)
 
-    if body.get("result") == "1019":  # token expired — try auto-refresh once
+    if body.get("result") == "1019":  # token expired — auto-refresh once
         if await _refresh_mobile_token(auth):
             body = await _do_request(auth.mobile_access_token)
 

--- a/server.py
+++ b/server.py
@@ -53,7 +53,7 @@ async def authenticate_coros(
     dict with keys: authenticated, user_id, region, message
     """
     try:
-        auth = await coros_api.login(email, password, region)
+        auth = await coros_api.login(email, password, region, skip_mobile=True)
         return {
             "authenticated": True,
             "user_id": auth.user_id,


### PR DESCRIPTION
## Summary
- `authenticate_coros` now passes `skip_mobile=True` so normal auth no longer triggers a mobile API login that logs the user out of the Coros mobile app
- Mobile token is still acquired lazily via auto-refresh when sleep data is first requested
- Updated README to document the new behavior

## Test plan
- [ ] Run `coros-mcp auth` and verify the mobile app stays logged in
- [ ] Request sleep data and verify the mobile token is obtained on-demand
- [ ] Verify subsequent sleep data requests auto-refresh an expired mobile token

🤖 Generated with [Claude Code](https://claude.com/claude-code)