### PR TITLE
feat: support repeat groups in workout creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Ask your AI assistant questions like:
 | `list_activities` | List activities for a date range with summary metrics |
 | `get_activity_detail` | Fetch full detail for a single activity (laps, HR zones, power zones) |
 | `list_workouts` | List all saved structured workout programs |
-| `create_workout` | Create a new structured workout with named steps and power targets |
+| `create_workout` | Create a new structured workout with steps, power targets, and repeat groups |
 | `list_planned_activities` | List planned workouts from the Coros training calendar |
 | `schedule_workout` | Schedule an existing workout on a calendar day |
 | `remove_scheduled_workout` | Remove a scheduled workout from the calendar |
@@ -238,7 +238,9 @@ Each workout includes: `id`, `name`, `sport_type`, `sport_name`, `estimated_time
 
 ### `create_workout`
 
-Create a new structured workout. Workouts appear in the Coros app and can be synced to the watch.
+Create a new structured workout. Workouts appear in the Coros app and can be synced to the watch. Steps can be plain steps or repeat groups for intervals.
+
+**Plain steps:**
 
 ```json
 {
@@ -250,6 +252,23 @@ Create a new structured workout. Workouts appear in the Coros app and can be syn
     {"name": "5:00 Pause",       "duration_minutes":  5, "power_low_w": 100, "power_high_w": 150},
     {"name": "20:00 Sweet Spot", "duration_minutes": 20, "power_low_w": 260, "power_high_w": 275},
     {"name": "30:00 Ausfahren",  "duration_minutes": 30, "power_low_w": 100, "power_high_w": 192}
+  ]
+}
+```
+
+**With repeat groups (intervals):**
+
+```json
+{
+  "name": "3×10min Sweetspot",
+  "sport_type": 2,
+  "steps": [
+    {"name": "Einfahren", "duration_minutes": 10, "power_low_w": 150, "power_high_w": 200},
+    {"repeat": 3, "steps": [
+      {"name": "Sweetspot", "duration_minutes": 10, "power_low_w": 265, "power_high_w": 285},
+      {"name": "Erholung",  "duration_minutes":  3, "power_low_w": 150, "power_high_w": 175}
+    ]},
+    {"name": "Ausfahren", "duration_minutes": 11, "power_low_w": 150, "power_high_w": 200}
   ]
 }
 ```

--- a/coros_api.py
+++ b/coros_api.py
@@ -562,36 +562,105 @@ async def create_workout(
     """
     Create a new structured workout program.
 
-    steps: list of dicts with keys:
+    steps: list of dicts — either plain steps or repeat groups.
+
+    Plain step:
       - name: str — step label (e.g. "10:00 Einfahren")
       - duration_minutes: float — step duration in minutes
       - power_low_w: int — lower power target in watts
       - power_high_w: int — upper power target in watts (0 = open-ended)
 
+    Repeat group:
+      - repeat: int — number of repetitions
+      - steps: list[dict] — sub-steps (same format as plain steps)
+
     Returns the new workout ID.
     """
     exercises = []
-    for i, step in enumerate(steps):
-        duration_s = int(step["duration_minutes"] * 60)
-        exercises.append({
-            "name": step["name"],
-            "exerciseType": 2,
-            "sportType": sport_type,
-            "intensityType": 6,           # power in watts
-            "intensityValue": step["power_low_w"],
-            "intensityValueExtend": step.get("power_high_w", 0),
-            "targetType": 2,              # time-based
-            "targetValue": duration_s,
-            "sets": 1,
-            "sortNo": 16777216 * (i + 1),
-            "restType": 3,
-            "restValue": 0,
-            "groupId": "0",
-            "isGroup": False,
-            "originId": "0",
-        })
+    top_index = 0  # counts top-level positions for sortNo
+    total_seconds = 0
+    ex_id = 0  # sequential exercise IDs (API uses these to link groups)
 
-    total_seconds = sum(int(s["duration_minutes"] * 60) for s in steps)
+    for step in steps:
+        if "repeat" in step:
+            # --- Repeat group ---
+            top_index += 1
+            ex_id += 1
+            group_sort = 16777216 * top_index
+            group_id = ex_id
+
+            sub_steps = step["steps"]
+            iteration_seconds = sum(
+                int(s["duration_minutes"] * 60) for s in sub_steps
+            )
+            total_seconds += iteration_seconds * step["repeat"]
+
+            # Group header exercise
+            exercises.append({
+                "id": group_id,
+                "name": "Group",
+                "exerciseType": 0,
+                "sportType": sport_type,
+                "intensityType": 0,
+                "intensityValue": 0,
+                "targetType": 2,
+                "targetValue": iteration_seconds,
+                "sets": step["repeat"],
+                "sortNo": group_sort,
+                "restType": 3,
+                "restValue": 0,
+                "groupId": "0",
+                "isGroup": True,
+                "originId": "0",
+            })
+
+            # Sub-step exercises
+            for j, sub in enumerate(sub_steps):
+                ex_id += 1
+                sub_duration = int(sub["duration_minutes"] * 60)
+                exercises.append({
+                    "id": ex_id,
+                    "name": sub["name"],
+                    "exerciseType": 2,
+                    "sportType": sport_type,
+                    "intensityType": 6,
+                    "intensityValue": sub["power_low_w"],
+                    "intensityValueExtend": sub.get("power_high_w", 0),
+                    "targetType": 2,
+                    "targetValue": sub_duration,
+                    "sets": 1,
+                    "sortNo": group_sort + 65536 * (j + 1),
+                    "restType": 3,
+                    "restValue": 0,
+                    "groupId": str(group_id),
+                    "isGroup": False,
+                    "originId": "0",
+                })
+        else:
+            # --- Plain step ---
+            top_index += 1
+            ex_id += 1
+            duration_s = int(step["duration_minutes"] * 60)
+            total_seconds += duration_s
+            exercises.append({
+                "id": ex_id,
+                "name": step["name"],
+                "exerciseType": 2,
+                "sportType": sport_type,
+                "intensityType": 6,
+                "intensityValue": step["power_low_w"],
+                "intensityValueExtend": step.get("power_high_w", 0),
+                "targetType": 2,
+                "targetValue": duration_s,
+                "sets": 1,
+                "sortNo": 16777216 * top_index,
+                "restType": 3,
+                "restValue": 0,
+                "groupId": "0",
+                "isGroup": False,
+                "originId": "0",
+            })
+
     payload = {
         "name": name,
         "sportType": sport_type,

--- a/server.py
+++ b/server.py
@@ -399,15 +399,25 @@ async def create_workout(
     name : str
         Workout name (e.g. "Z2 Erholung 60min").
     steps : list[dict]
-        List of workout steps. Each step must have:
+        List of workout steps. Each step is either a plain step or a repeat group.
+
+        Plain step:
           - name (str): step label, e.g. "10:00 Einfahren"
           - duration_minutes (float): step duration in minutes
           - power_low_w (int): lower power target in watts
           - power_high_w (int): upper power target in watts
+
+        Repeat group (for intervals):
+          - repeat (int): number of repetitions
+          - steps (list[dict]): sub-steps (same format as plain steps)
+
         Example:
           [
             {"name": "Einfahren", "duration_minutes": 10, "power_low_w": 148, "power_high_w": 192},
-            {"name": "Z2 Block", "duration_minutes": 40, "power_low_w": 192, "power_high_w": 221},
+            {"repeat": 3, "steps": [
+              {"name": "Sweetspot", "duration_minutes": 10, "power_low_w": 265, "power_high_w": 285},
+              {"name": "Erholung", "duration_minutes": 3, "power_low_w": 150, "power_high_w": 175},
+            ]},
             {"name": "Ausfahren", "duration_minutes": 10, "power_low_w": 100, "power_high_w": 165},
           ]
     sport_type : int
@@ -423,12 +433,21 @@ async def create_workout(
         return {"error": "Not authenticated."}
     try:
         workout_id = await coros_api.create_workout(auth, name, steps, sport_type)
-        total_minutes = sum(s["duration_minutes"] for s in steps)
+        total_minutes = 0
+        steps_count = 0
+        for s in steps:
+            if "repeat" in s:
+                sub_mins = sum(sub["duration_minutes"] for sub in s["steps"])
+                total_minutes += sub_mins * s["repeat"]
+                steps_count += 1 + len(s["steps"])
+            else:
+                total_minutes += s["duration_minutes"]
+                steps_count += 1
         return {
             "workout_id": workout_id,
             "name": name,
             "total_minutes": total_minutes,
-            "steps_count": len(steps),
+            "steps_count": steps_count,
             "message": "Workout created. Open Coros app → Workouts to sync to watch.",
         }
     except Exception as exc:


### PR DESCRIPTION
## Summary
- Cycling workouts can now contain repeat groups (e.g. 3×10min intervals) using the Coros Group exercise API
- Each group uses `exerciseType=0` with `isGroup=true`, and sub-steps reference the group via `groupId`
- Updated `create_workout` tool docs and README with repeat group syntax and examples

### New step format

Plain steps work as before. Repeat groups use a new `repeat` key:

```json
[
  {"name": "Einfahren", "duration_minutes": 10, "power_low_w": 150, "power_high_w": 200},
  {"repeat": 3, "steps": [
    {"name": "Sweetspot", "duration_minutes": 10, "power_low_w": 265, "power_high_w": 285},
    {"name": "Erholung", "duration_minutes": 3, "power_low_w": 150, "power_high_w": 175}
  ]},
  {"name": "Ausfahren", "duration_minutes": 11, "power_low_w": 150, "power_high_w": 200}
]
```

### Coros API details

Reverse-engineered from existing JOIN Cycling workouts:
- Group header: `exerciseType: 0`, `isGroup: true`, `sets: N`, `targetValue: iteration_seconds`
- Sub-steps: `groupId` references the group's `id`, `sortNo` offset by `65536 * index`
- All exercises need sequential `id` fields for the API to link sub-steps to their parent group

## Test plan
- [x] Created workout with 3×10min Sweetspot repeat group — verified correct group structure in Coros app
- [x] Verified existing plain-step workouts still work unchanged
- [x] Syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)