### PR TITLE
feat: add delete_workout tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Ask your AI assistant questions like:
 | `get_activity_detail` | Fetch full detail for a single activity (laps, HR zones, power zones) |
 | `list_workouts` | List all saved structured workout programs |
 | `create_workout` | Create a new structured workout with named steps and power targets |
+| `delete_workout` | Delete a workout program from the library |
 | `list_planned_activities` | List planned workouts from the Coros training calendar |
 | `schedule_workout` | Schedule an existing workout on a calendar day |
 | `remove_scheduled_workout` | Remove a scheduled workout from the calendar |
@@ -255,6 +256,18 @@ Create a new structured workout. Workouts appear in the Coros app and can be syn
 `sport_type`: `2` = Indoor Cycling (default), `200` = Road Bike
 
 Returns: `workout_id`, `name`, `total_minutes`, `steps_count`, `message`
+
+### `delete_workout`
+
+Delete a workout program from the Coros account.
+
+```json
+{ "workout_id": "476023839273435149" }
+```
+
+The `workout_id` comes from `list_workouts`.
+
+Returns: `deleted`, `workout_id`, `message`
 
 ### `list_planned_activities`
 

--- a/coros_api.py
+++ b/coros_api.py
@@ -40,6 +40,7 @@ ENDPOINTS = {
     "sport_types": "/activity/fit/getImportSportList",
     "workout_list": "/training/program/query",  # POST — list/fetch workout programs
     "workout_add": "/training/program/add",     # POST — create new structured workout
+    "workout_delete": "/training/program/delete",  # POST — delete workout(s), body: ["id1", ...]
     "schedule_sum": "/training/schedule/querysum",  # GET — planned calendar aggregates
     "schedule": "/training/schedule/query",         # GET — planned calendar detail
     "schedule_update": "/training/schedule/update", # POST — add workout to calendar
@@ -613,6 +614,21 @@ async def create_workout(
         raise ValueError(f"Coros workout create error: {body.get('message', 'unknown error')}")
 
     return str(body.get("data", ""))
+
+
+async def delete_workout(auth: StoredAuth, workout_id: str) -> None:
+    """Delete a workout program by ID."""
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["workout_delete"],
+            json=[workout_id],
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    if body.get("result") != "0000":
+        raise ValueError(f"Coros workout delete error: {body.get('message', 'unknown error')}")
 
 
 # ---------------------------------------------------------------------------

--- a/server.py
+++ b/server.py
@@ -436,6 +436,40 @@ async def create_workout(
 
 
 # ---------------------------------------------------------------------------
+# Tool: delete_workout
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def delete_workout(
+    workout_id: str,
+) -> dict:
+    """
+    Delete a workout program from the Coros account.
+
+    Parameters
+    ----------
+    workout_id : str
+        The workout ID to delete (from list_workouts).
+
+    Returns
+    -------
+    dict with keys: deleted, workout_id, message
+    """
+    auth = coros_api.get_stored_auth()
+    if auth is None:
+        return {"error": "Not authenticated."}
+    try:
+        await coros_api.delete_workout(auth, workout_id)
+        return {
+            "deleted": True,
+            "workout_id": workout_id,
+            "message": "Workout deleted.",
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
 # Tool: list_planned_activities
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- New MCP tool `delete_workout` to delete workout programs from the Coros account
- Uses `POST /training/program/delete` with a JSON array of workout IDs (reverse-engineered endpoint)
- Added tool documentation to README

### Usage

```json
{ "workout_id": "476023839273435149" }
```

The `workout_id` comes from `list_workouts`. Returns `{ "deleted": true, "workout_id": "...", "message": "Workout deleted." }`.

### API details

- Endpoint: `POST /training/program/delete`
- Body: JSON array of workout ID strings, e.g. `["476023839273435149"]`
- Returns `result: "0000"` on success

## Test plan
- [x] Successfully deleted test workouts via the API
- [x] Verified deleted workouts no longer appear in `list_workouts`
- [x] Syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)