### PR TITLE
docs: fix auth command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,14 @@ Run the following command in your terminal — **outside** of any Claude session
 coros-mcp auth
 ```
 
-You will be prompted for your email, password, and region (`eu`, `us`, or `asia`). This stores the Training Hub web token. Your credentials are sent directly to Coros and the token is stored securely in your system keyring (or an encrypted local file as fallback). **You only need to do this once** — the token persists across restarts.
+You will be prompted for your email, password, and region (`eu`, `us`, or `asia`). This stores both the Training Hub web token and the mobile API token (used for sleep data). Your credentials are sent directly to Coros and the tokens are stored securely in your system keyring (or an encrypted local file as fallback). **You only need to do this once** — the tokens persist across restarts.
 
-> **Note:** `coros-mcp auth` does **not** obtain a mobile API token (used for sleep data), because the mobile login invalidates any existing mobile app session on your phone. The mobile token is obtained automatically when you first request sleep data, or you can run `coros-mcp auth-mobile` manually.
+> **Note:** The mobile login (`apieu.coros.com`) will log you out of the Coros mobile app on your phone. If you want to avoid this, use `coros-mcp auth-web` instead — it stores only the web token, and the mobile token will be obtained automatically when you first request sleep data.
 
 **Other auth commands:**
 
 ```bash
+coros-mcp auth-web      # Web API only — skips mobile login (sleep data obtained lazily)
 coros-mcp auth-mobile   # Mobile API only (sleep data)
 coros-mcp auth-status   # Check if authenticated
 coros-mcp auth-clear    # Remove stored tokens
@@ -199,7 +200,7 @@ Each record includes:
 | `max_hr` | Maximum heart rate during sleep |
 | `quality_score` | Sleep quality score (null if not computed) |
 
-> **Note:** Sleep data is fetched from the Coros mobile API (`apieu.coros.com`), which uses a separate token from the Training Hub web API. The mobile token is **not** obtained during `coros-mcp auth` to avoid logging you out of the Coros mobile app. Instead, it is obtained automatically when you first request sleep data (which will log you out of the app). The token expires after ~1 hour but **refreshes automatically** on subsequent requests.
+> **Note:** Sleep data is fetched from the Coros mobile API (`apieu.coros.com`), which uses a separate token from the Training Hub web API. `coros-mcp auth` obtains both tokens, but doing so logs you out of the Coros mobile app. Use `coros-mcp auth-web` to skip mobile login — the mobile token is then obtained automatically on the first sleep data request. The token expires after ~1 hour but **refreshes automatically** on subsequent requests.
 
 ### `list_activities`
 


### PR DESCRIPTION
- Add missing `auth-web` command (web-only auth, skips mobile login)
- Correct the description of `coros-mcp auth`: it obtains both web and
  mobile tokens (not web-only as previously stated)
- Clarify that `auth-web` is the right choice to avoid being logged out
  of the Coros mobile app
- Update the sleep data note accordingly

https://claude.ai/code/session_01MpPvQQsUtf2q2ShoGqGy9N