### PR TITLE
refactor: code review fixes — bug fix, deduplication, and efficiency improvements

### DIFF
--- a/auth/encrypted_store.py
+++ b/auth/encrypted_store.py
@@ -6,6 +6,7 @@ Uses AES-256-GCM with a machine-bound key.
 
 import base64
 import contextlib
+import functools
 import hashlib
 import os
 import platform
@@ -20,6 +21,7 @@ CONFIG_DIR = Path.home() / ".config" / "coros-mcp"
 CREDENTIALS_FILE = CONFIG_DIR / "auth.enc"
 
 
+@functools.lru_cache(maxsize=1)
 def _get_machine_id() -> bytes:
     components = [
         platform.node(),
@@ -75,20 +77,19 @@ def store_credential_encrypted(token: str) -> CredentialResult:
 
 
 def get_credential_encrypted() -> CredentialResult:
-    if not CREDENTIALS_FILE.exists():
-        return CredentialResult(success=False, message="No credential file found")
     try:
         data = base64.b64decode(CREDENTIALS_FILE.read_bytes())
         token = AESGCM(_derive_key()).decrypt(data[:12], data[12:], None).decode()
         return CredentialResult(success=True, message="Token retrieved", token=token)
+    except FileNotFoundError:
+        return CredentialResult(success=False, message="No credential file found")
     except Exception as e:
         return CredentialResult(success=False, message=f"Decryption error: {e}")
 
 
 def clear_credential_encrypted() -> CredentialResult:
     try:
-        if CREDENTIALS_FILE.exists():
-            CREDENTIALS_FILE.unlink()
+        CREDENTIALS_FILE.unlink(missing_ok=True)
         return CredentialResult(success=True, message="Credential file removed")
     except Exception as e:
         return CredentialResult(success=False, message=f"Error removing file: {e}")

--- a/cli.py
+++ b/cli.py
@@ -2,9 +2,30 @@
 import asyncio
 import getpass
 import sys
+import time
 
 from auth.storage import clear_token, get_token, is_keyring_available
-from coros_api import get_stored_auth, login, login_mobile
+from coros_api import TOKEN_TTL_MS, get_stored_auth, login, login_mobile
+
+
+def _prompt_credentials() -> tuple[str, str, str]:
+    """Prompt for email, password, and region. Returns (email, password, region)."""
+    email = input("Email: ").strip()
+    if not email:
+        print("Error: email is required.")
+        sys.exit(1)
+
+    password = getpass.getpass("Password: ")
+    if not password:
+        print("Error: password is required.")
+        sys.exit(1)
+
+    print()
+    print("Region options: eu, us, asia")
+    region = input("Region [eu]: ").strip().lower() or "eu"
+    if region not in ("eu", "us", "asia"):
+        print(f"Warning: unknown region '{region}', using it anyway.")
+    return email, password, region
 
 
 def cmd_auth() -> int:
@@ -18,22 +39,7 @@ def cmd_auth() -> int:
         print("System keyring not available — token will be stored in an encrypted local file.")
     print()
 
-    email = input("Email: ").strip()
-    if not email:
-        print("Error: email is required.")
-        return 1
-
-    password = getpass.getpass("Password: ")
-    if not password:
-        print("Error: password is required.")
-        return 1
-
-    print()
-    print("Region options: eu, us, asia")
-    region = input("Region [eu]: ").strip().lower() or "eu"
-    if region not in ("eu", "us", "asia"):
-        print(f"Warning: unknown region '{region}', using it anyway.")
-
+    email, password, region = _prompt_credentials()
     print()
     print("Authenticating…")
     try:
@@ -51,22 +57,7 @@ def cmd_auth_web() -> int:
     print("Coros MCP — Web API Authentication")
     print()
 
-    email = input("Email: ").strip()
-    if not email:
-        print("Error: email is required.")
-        return 1
-
-    password = getpass.getpass("Password: ")
-    if not password:
-        print("Error: password is required.")
-        return 1
-
-    print()
-    print("Region options: eu, us, asia")
-    region = input("Region [eu]: ").strip().lower() or "eu"
-    if region not in ("eu", "us", "asia"):
-        print(f"Warning: unknown region '{region}', using it anyway.")
-
+    email, password, region = _prompt_credentials()
     print()
     print("Authenticating (web only)…")
     try:
@@ -84,22 +75,7 @@ def cmd_auth_mobile() -> int:
     print("Coros MCP — Mobile API Authentication")
     print()
 
-    email = input("Email: ").strip()
-    if not email:
-        print("Error: email is required.")
-        return 1
-
-    password = getpass.getpass("Password: ")
-    if not password:
-        print("Error: password is required.")
-        return 1
-
-    print()
-    print("Region options: eu, us, asia")
-    region = input("Region [eu]: ").strip().lower() or "eu"
-    if region not in ("eu", "us", "asia"):
-        print(f"Warning: unknown region '{region}', using it anyway.")
-
+    email, password, region = _prompt_credentials()
     print()
     print("Authenticating (mobile only)…")
     try:
@@ -116,9 +92,7 @@ def cmd_auth_status() -> int:
     """Check whether valid tokens are stored."""
     auth = get_stored_auth()
     if auth:
-        import time
         age_ms = int(time.time() * 1000) - auth.timestamp
-        from coros_api import TOKEN_TTL_MS
         remaining_hours = round((TOKEN_TTL_MS - age_ms) / 3_600_000, 1)
 
         # Web token status
@@ -143,7 +117,6 @@ def cmd_auth_status() -> int:
         else:
             print("✗ Not authenticated. Run 'coros-mcp auth' to log in.")
         return 1
-
 
 
 def cmd_auth_clear() -> int:

--- a/coros_api.py
+++ b/coros_api.py
@@ -6,6 +6,7 @@ HRV data comes from /dashboard/query (last 7 days of nightly RMSSD).
 Sleep phase data comes from the mobile API (/coros/data/statistic/daily on apieu.coros.com).
 """
 
+import asyncio
 import hashlib
 import json
 import random
@@ -61,6 +62,12 @@ MOBILE_BASE_URLS = {
 }
 
 TOKEN_TTL_MS = 24 * 60 * 60 * 1000  # 24 hours in milliseconds
+
+
+def _check_response(body: dict, context: str) -> None:
+    """Raise ValueError if the Coros API response indicates an error."""
+    if body.get("result") != "0000":
+        raise ValueError(f"Coros {context} error: {body.get('message', 'unknown error')}")
 
 
 # ---------------------------------------------------------------------------
@@ -156,8 +163,7 @@ async def _mobile_login(email: str, password: str, region: str = "eu") -> tuple[
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros mobile login failed: {body.get('message', 'unknown error')}")
+    _check_response(body, "mobile login")
 
     token = body.get("data", {}).get("accessToken")
     if not token:
@@ -198,8 +204,7 @@ async def login(email: str, password: str, region: str = "eu", *, skip_mobile: b
         resp.raise_for_status()
         body = resp.json()
 
-        if body.get("result") != "0000":
-            raise ValueError(f"Coros login failed: {body.get('message', 'unknown error')}")
+        _check_response(body, "login")
 
         data = body.get("data", {})
 
@@ -235,8 +240,10 @@ async def login_mobile(email: str, password: str, region: str = "eu") -> StoredA
 
     existing = _load_auth()
     if existing:
-        existing.mobile_access_token = mobile_token
-        existing.mobile_login_payload = mobile_payload
+        existing = existing.model_copy(update={
+            "mobile_access_token": mobile_token,
+            "mobile_login_payload": mobile_payload,
+        })
         _save_auth(existing)
         return existing
 
@@ -290,8 +297,7 @@ async def fetch_hrv(auth: StoredAuth) -> list[HRVRecord]:
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros dashboard API error: {body.get('message', 'unknown error')}")
+    _check_response(body, "dashboard")
 
     hrv_data = body.get("data", {}).get("summaryInfo", {}).get("sleepHrvData", {})
     records: list[HRVRecord] = []
@@ -361,25 +367,23 @@ async def fetch_daily_records(
     base = _base_url(auth.region)
 
     async with httpx.AsyncClient(timeout=30) as client:
-        detail_resp = await client.get(
-            base + ENDPOINTS["analyse_detail"],
-            params={"startDay": start_day, "endDay": end_day},
-            headers=headers,
+        detail_resp, analyse_resp = await asyncio.gather(
+            client.get(
+                base + ENDPOINTS["analyse_detail"],
+                params={"startDay": start_day, "endDay": end_day},
+                headers=headers,
+            ),
+            client.get(
+                base + ENDPOINTS["analyse"],
+                headers=headers,
+            ),
         )
-        detail_resp.raise_for_status()
-        detail_body = detail_resp.json()
+    detail_resp.raise_for_status()
+    detail_body = detail_resp.json()
+    analyse_resp.raise_for_status()
+    analyse_body = analyse_resp.json()
 
-        analyse_resp = await client.get(
-            base + ENDPOINTS["analyse"],
-            headers=headers,
-        )
-        analyse_resp.raise_for_status()
-        analyse_body = analyse_resp.json()
-
-    if detail_body.get("result") != "0000":
-        raise ValueError(
-            f"Coros analyse API error: {detail_body.get('message', 'unknown error')}"
-        )
+    _check_response(detail_body, "analyse")
 
     # Build records from dayDetail (long range)
     records_by_date: dict[str, DailyRecord] = {}
@@ -421,8 +425,8 @@ def _parse_activity(item: dict) -> ActivitySummary:
         name=item.get("name") or item.get("remark"),
         sport_type=sport_type,
         sport_name=SPORT_NAMES.get(sport_type, f"Sport {sport_type}") if sport_type else None,
-        start_time=str(item.get("startTime", "")) or None,
-        end_time=str(item.get("endTime", "")) or None,
+        start_time=str(item["startTime"]) if item.get("startTime") else None,
+        end_time=str(item["endTime"]) if item.get("endTime") else None,
         duration_seconds=item.get("totalTime"),
         distance_meters=item.get("totalDistance"),
         avg_hr=item.get("avgHr"),
@@ -465,8 +469,7 @@ async def fetch_activities(
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros activity API error: {body.get('message', 'unknown error')}")
+    _check_response(body, "activity list")
 
     data = body.get("data", {})
     items = data.get("dataList", data.get("list", []))
@@ -489,8 +492,7 @@ async def fetch_activity_detail(auth: StoredAuth, activity_id: str, sport_type: 
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros activity detail API error: {body.get('message', 'unknown error')}")
+    _check_response(body, "activity detail")
 
     data = body.get("data", {})
     # Strip large time-series arrays that bloat the response
@@ -548,8 +550,7 @@ async def fetch_workouts(auth: StoredAuth) -> list[dict]:
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros workout API error: {body.get('message', 'unknown error')}")
+    _check_response(body, "workout list")
 
     return [_parse_workout(w) for w in body.get("data", [])]
 
@@ -679,8 +680,7 @@ async def create_workout(
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros workout create error: {body.get('message', 'unknown error')}")
+    _check_response(body, "workout create")
 
     return str(body.get("data", ""))
 
@@ -696,8 +696,7 @@ async def delete_workout(auth: StoredAuth, workout_id: str) -> None:
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros workout delete error: {body.get('message', 'unknown error')}")
+    _check_response(body, "workout delete")
 
 
 # ---------------------------------------------------------------------------
@@ -728,22 +727,21 @@ async def fetch_schedule(
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros schedule API error: {body.get('message', 'unknown error')}")
+    _check_response(body, "schedule")
 
     return _strip_schedule(body.get("data") or {})
 
 
-_EXERCISE_DROP = {
+_EXERCISE_DROP = frozenset({
     "videoInfos", "videoUrl", "videoUrlArrStr", "coverUrlArrStr",
     "thumbnailUrl", "sourceUrl", "animationId",
     "access", "deleted", "defaultOrder", "status", "createTimestamp",
     "userId", "muscle", "muscleRelevance", "part", "equipment",
     "sortNo", "originId", "isDefaultAdd", "intensityCustom",
     "intensityDisplayUnit", "isIntensityPercent",
-}
+})
 
-_PROGRAM_DROP = {
+_PROGRAM_DROP = frozenset({
     "exerciseBarChart", "headPic", "profile", "sex", "star", "nickname",
     "essence", "originEssence", "access", "authorId", "deleted", "pbVersion",
     "version", "status", "createTimestamp", "thirdPartyId",
@@ -751,22 +749,26 @@ _PROGRAM_DROP = {
     "distanceDisplayUnit", "elevGain", "estimatedDistance", "estimatedTime",
     "estimatedType", "strengthType", "targetType", "targetValue",
     "planId", "planIdIndex", "userId",
-}
+})
 
-_ENTITY_DROP = {
+_ENTITY_DROP = frozenset({
     "exerciseBarChart", "completeRate", "score", "standardRate",
     "dayNo", "operateUserId", "thirdParty", "thirdPartyId",
     "sortNo", "sortNoInSchedule", "userId", "planId", "planIdIndex",
-}
+})
 
-_TOP_DROP = {
+_TOP_DROP = frozenset({
     "sportDatasInPlan", "sportDatasNotInPlan", "likeTpIds", "starTimestamp",
     "score", "sourceUrl", "inSchedule", "pauseInApp", "access", "authorId",
     "category", "pbVersion", "version", "thirdPartyId", "maxIdInPlan",
     "maxPlanProgramId", "weekStages", "subPlans", "userInfos",
     "type", "unit", "totalDay", "status", "startDay", "createTime",
     "updateTimestamp", "userId",
-}
+})
+
+
+def _drop_keys(d: dict, keys: frozenset) -> dict:
+    return {k: v for k, v in d.items() if k not in keys}
 
 
 def _readable_overview(overview: str) -> str:
@@ -779,26 +781,23 @@ def _readable_overview(overview: str) -> str:
 
 
 def _strip_exercise(ex: dict) -> dict:
-    out = {k: v for k, v in ex.items() if k not in _EXERCISE_DROP}
+    out = _drop_keys(ex, _EXERCISE_DROP)
     if "overview" in out:
         out["overview"] = _readable_overview(out["overview"])
     return out
 
 
 def _strip_program(prog: dict) -> dict:
-    out = {k: v for k, v in prog.items() if k not in _PROGRAM_DROP}
+    out = _drop_keys(prog, _PROGRAM_DROP)
     if "exercises" in out:
         out["exercises"] = [_strip_exercise(e) for e in out["exercises"]]
     return out
 
 
 def _strip_schedule(data: dict) -> dict:
-    out = {k: v for k, v in data.items() if k not in _TOP_DROP}
+    out = _drop_keys(data, _TOP_DROP)
     if "entities" in out:
-        out["entities"] = [
-            {k: v for k, v in e.items() if k not in _ENTITY_DROP}
-            for e in out["entities"]
-        ]
+        out["entities"] = [_drop_keys(e, _ENTITY_DROP) for e in out["entities"]]
     if "programs" in out:
         out["programs"] = [_strip_program(p) for p in out["programs"]]
     return out
@@ -927,8 +926,7 @@ async def create_strength_workout(
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros strength workout create error: {body.get('message', 'unknown error')}")
+    _check_response(body, "strength workout create")
 
     return str(body.get("data", ""))
 
@@ -1009,8 +1007,7 @@ async def schedule_workout(
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros schedule update error: {body.get('message', 'unknown error')}")
+    _check_response(body, "schedule update")
 
 
 async def remove_scheduled_workout(
@@ -1044,8 +1041,7 @@ async def remove_scheduled_workout(
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros schedule delete error: {body.get('message', 'unknown error')}")
+    _check_response(body, "schedule delete")
 
 
 async def fetch_exercises(auth: StoredAuth, sport_type: int) -> list[dict]:
@@ -1066,8 +1062,7 @@ async def fetch_exercises(auth: StoredAuth, sport_type: int) -> list[dict]:
         resp.raise_for_status()
         body = resp.json()
 
-    if body.get("result") != "0000":
-        raise ValueError(f"Coros exercise API error: {body.get('message', 'unknown error')}")
+    _check_response(body, "exercise list")
 
     return body.get("data", []) or []
 

--- a/server.py
+++ b/server.py
@@ -13,16 +13,33 @@ MCP config (Claude Code):
 """
 
 import os
+import time
 from datetime import datetime, timedelta
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 
 import coros_api
+from coros_api import TOKEN_TTL_MS
 
 load_dotenv()
 
 mcp = FastMCP("coros-mcp")
+
+
+def _summarize_steps(steps: list[dict]) -> tuple[float, int]:
+    """Return (total_minutes, steps_count) for a workout step list."""
+    total_minutes = 0.0
+    steps_count = 0
+    for s in steps:
+        if "repeat" in s:
+            sub_mins = sum(sub["duration_minutes"] for sub in s["steps"])
+            total_minutes += sub_mins * s["repeat"]
+            steps_count += 1 + len(s["steps"])
+        else:
+            total_minutes += s["duration_minutes"]
+            steps_count += 1
+    return total_minutes, steps_count
 
 
 # ---------------------------------------------------------------------------
@@ -134,9 +151,8 @@ async def check_coros_auth() -> dict:
             "message": "No valid token found. Call authenticate_coros first.",
         }
 
-    import time
     age_ms = int(time.time() * 1000) - auth.timestamp
-    remaining_ms = coros_api.TOKEN_TTL_MS - age_ms
+    remaining_ms = TOKEN_TTL_MS - age_ms
     remaining_hours = round(remaining_ms / 3_600_000, 1)
 
     has_mobile = bool(auth.mobile_access_token)
@@ -413,12 +429,12 @@ async def create_workout(
 
         Example:
           [
-            {"name": "Einfahren", "duration_minutes": 10, "power_low_w": 148, "power_high_w": 192},
+            {"name": "Warm-up", "duration_minutes": 10, "power_low_w": 148, "power_high_w": 192},
             {"repeat": 3, "steps": [
               {"name": "Sweetspot", "duration_minutes": 10, "power_low_w": 265, "power_high_w": 285},
-              {"name": "Erholung", "duration_minutes": 3, "power_low_w": 150, "power_high_w": 175},
+              {"name": "Recovery", "duration_minutes": 3, "power_low_w": 150, "power_high_w": 175},
             ]},
-            {"name": "Ausfahren", "duration_minutes": 10, "power_low_w": 100, "power_high_w": 165},
+            {"name": "Cool-down", "duration_minutes": 10, "power_low_w": 100, "power_high_w": 165},
           ]
     sport_type : int
         Sport type ID. Default 2 = Indoor Cycling (Rollen).
@@ -433,16 +449,7 @@ async def create_workout(
         return {"error": "Not authenticated."}
     try:
         workout_id = await coros_api.create_workout(auth, name, steps, sport_type)
-        total_minutes = 0
-        steps_count = 0
-        for s in steps:
-            if "repeat" in s:
-                sub_mins = sum(sub["duration_minutes"] for sub in s["steps"])
-                total_minutes += sub_mins * s["repeat"]
-                steps_count += 1 + len(s["steps"])
-            else:
-                total_minutes += s["duration_minutes"]
-                steps_count += 1
+        total_minutes, steps_count = _summarize_steps(steps)
         return {
             "workout_id": workout_id,
             "name": name,


### PR DESCRIPTION
- fix: _parse_activity start_time/end_time: str(None) produced "None" string instead of None
- perf: fetch_daily_records now fires both API calls in parallel via asyncio.gather()
- refactor: extract _check_response() to replace 13 identical error-check blocks
- refactor: extract _drop_keys() helper; convert drop-key sets to frozenset
- refactor: extract _summarize_steps() in server.py, removing duplicated step-iteration
- refactor: extract _prompt_credentials() in cli.py, deduplicating three auth commands
- refactor: use model_copy() in login_mobile() instead of direct Pydantic field mutation
- fix: remove TOCTOU checks in encrypted_store.py (unlink missing_ok, FileNotFoundError)
- perf: add @lru_cache to _get_machine_id() to avoid repeated subprocess/file reads
- style: move deferred imports (time, TOKEN_TTL_MS) to module level in server.py + cli.py
- style: translate German example names in create_workout docstring to English

https://claude.ai/code/session_018wD6o4KH4FjdsoN4GdejuG