### PR TITLE
fix: correct activity pagination by reading API's count field

### DIFF
--- a/coros_api.py
+++ b/coros_api.py
@@ -505,7 +505,7 @@ async def fetch_activities(
 
     data = body.get("data", {})
     items = data.get("dataList", data.get("list", []))
-    total = data.get("totalCount", len(items))
+    total = data.get("totalCount") or data.get("count") or len(items)
     return [_parse_activity(i) for i in items], total
 
 


### PR DESCRIPTION
## Summary

Fixes a pagination bug in `fetch_activities()` that caused only the first page (100 activities) to be returned instead of the full dataset.

## Root Cause

The `/activity/query` endpoint surfaces the total count in the `count` field of the response data object. The previous code read `totalCount` which was always `null` for this endpoint, falling back to `len(items)` — the current page size (100). The pagination loop termination check `page_num * 100 >= total` evaluated to `100 >= 100` on the first iteration, stopping pagination prematurely.

## Fix

```python
# Before
total = data.get("totalCount", len(items))

# After
total = data.get("totalCount") or data.get("count") or len(items)
```

Now correctly reads `count` when `totalCount` is absent, matching the actual Coros API response schema.

## Test Result

| Scenario | Before | After |
|----------|--------|-------|
| Full activity sync (326 total, 4 pages) | 100 | 326 |

## Test plan

- [x] `fetch_activities()` returns correct total (326) across all pages
- [x] Full sync stores all 326 activities in SQLite cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)