### PR TITLE
fix: prefer encrypted file over keyring for MCP subprocess compatibility

### DIFF
--- a/auth/storage.py
+++ b/auth/storage.py
@@ -35,18 +35,23 @@ def store_token(token: str) -> CredentialResult:
 def get_token() -> CredentialResult:
     """Retrieve the Coros access token.
 
-    Priority: env var → keyring → encrypted file.
+    Priority: env var → encrypted file → keyring.
+    Encrypted file is checked first because keyring may hang in subprocess
+    environments (e.g. MCP server launched by Claude Code / OpenClaw) where
+    macOS Keychain requires interactive unlock.
     """
     env = os.environ.get(ENV_VAR)
     if env:
         return CredentialResult(success=True, message="Token from env var", token=env)
 
-    if is_keyring_available():
-        result = _keyring_get()
-        if result.success:
-            return result
+    result = get_credential_encrypted()
+    if result.success:
+        return result
 
-    return get_credential_encrypted()
+    if is_keyring_available():
+        return _keyring_get()
+
+    return result
 
 
 def clear_token() -> CredentialResult:

--- a/coros_api.py
+++ b/coros_api.py
@@ -265,7 +265,25 @@ async def login_mobile(email: str, password: str, region: str = "eu") -> StoredA
 
 
 def get_stored_auth() -> Optional[StoredAuth]:
-    """Return stored auth if it exists and is not expired."""
+    """Return stored auth if it exists and is not expired.
+    
+    When COROS_ACCESS_TOKEN env var is set, it takes precedence over
+    stored keyring/encrypted-file auth (for MCP server use cases where
+    keyring is not accessible in the subprocess).
+    """
+    # Prefer explicit env var token when provided
+    access_token = os.environ.get("COROS_ACCESS_TOKEN")
+    if access_token:
+        region = os.environ.get("COROS_REGION", "eu")
+        return StoredAuth(
+            access_token=access_token,
+            user_id="env",
+            region=region,
+            timestamp=int(time.time() * 1000),
+            mobile_access_token=None,
+            mobile_login_payload=None,
+        )
+    # Fall back to stored auth
     auth = _load_auth()
     if auth and _is_token_valid(auth):
         return auth


### PR DESCRIPTION
## Summary

Changes token retrieval priority so the encrypted auth file is read before the macOS Keychain, avoiding Keychain hangs in non-interactive MCP subprocess contexts (e.g. OpenClaw). Also honours the `COROS_ACCESS_TOKEN` env var as the highest-priority token source, enabling token injection without any file or Keychain access.

## Changes

- **auth/storage.py**: `get_token()` now reads the encrypted file before attempting Keychain lookup
- **coros_api.py**: `get_stored_auth()` checks `COROS_ACCESS_TOKEN` env var first

## Why

The macOS Keychain API can block indefinitely when called from a non-interactive subprocess that has not connected to a window server. MCP servers launched by Claude Code typically run in this environment. Reading the encrypted file first avoids the Keychain entirely in the common case where a token file already exists.

## Test plan

- [x] `coros-mcp sync` works without Keychain access when `.env` credentials are set
- [x] Token injection via `COROS_ACCESS_TOKEN` env var works independently of file/Keychain

🤖 Generated with [Claude Code](https://claude.com/claude-code)