### PR TITLE
fix: correct field names and calorie unit in _parse_activity

### DIFF
--- a/coros_api.py
+++ b/coros_api.py
@@ -478,14 +478,14 @@ def _parse_activity(item: dict) -> ActivitySummary:
         start_time=str(item["startTime"]) if item.get("startTime") else None,
         end_time=str(item["endTime"]) if item.get("endTime") else None,
         duration_seconds=item.get("totalTime"),
-        distance_meters=item.get("totalDistance"),
+        distance_meters=item.get("distance") or item.get("totalDistance"),
         avg_hr=item.get("avgHr"),
         max_hr=item.get("maxHr"),
-        calories=item.get("calorie") or item.get("totalCalorie"),
+        calories=round((item.get("calorie") or item.get("totalCalorie") or 0) / 1000) or None,
         training_load=item.get("trainingLoad"),
         avg_power=item.get("avgPower"),
         normalized_power=item.get("np"),
-        elevation_gain=item.get("totalAscent") or item.get("elevationGain"),
+        elevation_gain=item.get("ascent") or item.get("totalAscent") or item.get("elevationGain"),
     )
 
 


### PR DESCRIPTION
The `list_activities` API response does not contain `totalDistance` or `totalAscent`. The actual field names are `distance` and `ascent`. This caused both to return `null` for every activity.

The `calorie` field is returned in milliCalories (e.g. `893468` for a 90-minute run), not kilocalories. Dividing by 1000 gives the correct value.

**Changes:**
- `distance_meters`: read `distance` first (falls back to `totalDistance`)
- `elevation_gain`: read `ascent` first (falls back to `totalAscent`, then `elevationGain`)
- `calories`: divide raw value by 1000

Verified against a live Coros account (PACE 4, EU region).