### PR TITLE
feat: expose elevation_loss (descent) in ActivitySummary

### DIFF
--- a/coros_api.py
+++ b/coros_api.py
@@ -487,6 +487,7 @@ def _parse_activity(item: dict) -> ActivitySummary:
         avg_power=item.get("avgPower"),
         normalized_power=item.get("np"),
         elevation_gain=item.get("ascent") if item.get("ascent") is not None else (item.get("totalAscent") if item.get("totalAscent") is not None else item.get("elevationGain")),
+        elevation_loss=item.get("descent") if item.get("descent") is not None else item.get("totalDescent"),
     )
 
 

--- a/models.py
+++ b/models.py
@@ -65,6 +65,7 @@ class ActivitySummary(BaseModel):
     avg_power: Optional[int] = None
     normalized_power: Optional[int] = None
     elevation_gain: Optional[int] = None
+    elevation_loss: Optional[int] = None
 
 
 class StoredAuth(BaseModel):


### PR DESCRIPTION
The activity list response includes `descent` and `totalDescent` fields that are not currently surfaced in `ActivitySummary`.

For trail running and cycling, descent is as relevant as ascent — it represents eccentric leg load and directly affects recovery. Omitting it gives an incomplete picture of training stress.

**Changes:**
- `models.py`: add `elevation_loss: Optional[int]` to `ActivitySummary`
- `coros_api.py`: map `descent`/`totalDescent` → `elevation_loss`

Verified against a live Coros account (PACE 4, EU region).