### PR TITLE
feat: support per-exercise sets in create_strength_workout

### DIFF
--- a/coros_api.py
+++ b/coros_api.py
@@ -880,7 +880,8 @@ async def create_strength_workout(
     for i, ex in enumerate(exercises):
         target_value = ex["target_value"]
         rest = ex.get("rest_seconds", 60)
-        total_duration += (target_value if ex["target_type"] == 2 else 0) + rest
+        ex_sets = ex.get("sets", 1)
+        total_duration += ((target_value if ex["target_type"] == 2 else 0) + rest) * ex_sets
         built.append({
             "access": 0,
             "createTimestamp": 0,
@@ -906,7 +907,7 @@ async def create_strength_workout(
             "groupId": "",
             "restType": 1,
             "restValue": rest,
-            "sets": 1,
+            "sets": ex.get("sets", 1),
             "sortNo": i,
             "sourceUrl": "",
             "sportType": 4,

--- a/server.py
+++ b/server.py
@@ -674,8 +674,12 @@ async def create_strength_workout(
         - target_type (int): 2=time in seconds, 3=reps
         - target_value (int): number of seconds or reps
         - rest_seconds (int): rest after this exercise (default 60)
+        - sets (int, optional): number of consecutive sets of this exercise
+          (default 1). Use this to get "3 sets of face pull in a row" instead
+          of having to duplicate the exercise entry 3 times.
     sets : int
-        Number of circuit repetitions (default 1).
+        Number of full-circuit repetitions over the whole exercise list
+        (default 1). Distinct from the per-exercise `sets` above.
 
     Returns
     -------


### PR DESCRIPTION
## Summary

The Coros API payload already carries a `sets` field **per exercise** (it is what the mobile app's "Repeat" counter writes), but `coros_api.create_strength_workout` was hardcoding it to `1`. As a result, callers who wanted "3 consecutive sets of face pulls, then 3 of rows, …" had to duplicate every exercise entry 3 times instead of just setting `sets: 3`.

This PR simply forwards the per-exercise `sets` value when building the payload.

## Changes

- **`coros_api.py`** — `create_strength_workout` now reads `ex.get("sets", 1)` instead of the hardcoded `1` when building each exercise dict. The `total_duration` calculation is updated to multiply seconds + rest by the exercise's own sets count so the workout's overall duration stays accurate.
- **`server.py`** — `create_strength_workout` tool docstring documents the new optional per-exercise `sets` field and clarifies the distinction with the workout-level circuit `sets` parameter.

## Backward compatibility

Fully backward compatible: exercises without a `sets` key default to `1`, matching the previous behavior. Every existing call site continues to work unchanged.

## Verification

Tested against a live Coros EU account:
- Built a 7-entry strength workout with per-exercise `sets: 3` on the main lifts.
- The Coros API accepted the payload, and the workout renders correctly with "× 3 sets" shown per exercise in the mobile app — identical to what the app produces natively when you tap its "Repeat" button.
- Previously the same workout required 17 duplicated entries to achieve the same structure.

## Notes

Interestingly, the same file (`coros_api.py`) already reads `ex.get("sets", 1)` in another function around line 579, which was the hint that the API supports it — `create_strength_workout` was just the odd one out.