### PR TITLE
docs: clarify calories field unit (cal → kcal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ List activities for a date range.
 
 Returns: `activities` (list), `total_count`, `page`
 
-Each activity includes: `activity_id`, `name`, `sport_type`, `sport_name`, `start_time`, `end_time`, `duration_seconds`, `distance_meters`, `avg_hr`, `max_hr`, `calories`, `training_load`, `avg_power`, `normalized_power`, `elevation_gain`
+Each activity includes: `activity_id`, `name`, `sport_type`, `sport_name`, `start_time`, `end_time`, `duration_seconds`, `distance_meters`, `avg_hr`, `max_hr`, `calories` (in cal — divide by 1000 for kcal), `training_load`, `avg_power`, `normalized_power`, `elevation_gain`
 
 ### `get_activity_detail`
 

--- a/coros_api.py
+++ b/coros_api.py
@@ -469,7 +469,12 @@ SPORT_NAMES: dict[int, str] = {
 
 def _parse_activity(item: dict) -> ActivitySummary:
     sport_type = item.get("sportType")
-    cal_raw = item.get("calorie")  # API field "calorie" is in cal (calories)
+    # The Coros API field "calorie" is in physical calories (cal), NOT kilocalories (kcal).
+    # A typical 60-minute run returns ~600 000 cal, which equals 600 kcal.
+    # This is counterintuitive because consumer fitness apps and nutrition labels
+    # always display energy in kcal (sometimes written as "Calories" with a capital C).
+    # We store the raw value as-is; callers must divide by 1000 to get kcal.
+    cal_raw = item.get("calorie")
     return ActivitySummary(
         activity_id=str(item.get("labelId", "")),
         name=item.get("name") or item.get("remark"),

--- a/server.py
+++ b/server.py
@@ -358,7 +358,8 @@ async def list_activities(
     Each activity contains: activity_id, name, sport_type, sport_name,
     start_time (local datetime string "YYYY-MM-DD HH:MM:SS", per COROS_TIMEZONE),
     end_time (same format), duration_seconds, distance_meters, avg_hr, max_hr,
-    calories, training_load, avg_power, normalized_power, elevation_gain.
+    calories (in cal — divide by 1000 to get kcal), training_load, avg_power,
+    normalized_power, elevation_gain.
     """
     auth = await _get_auth()
     if auth is None:


### PR DESCRIPTION
## Summary
- Add inline note to `list_activities` docstring: `calories` is in cal, divide by 1000 for kcal
- Same note added to README field list for `list_activities`

## Test plan
- [ ] No logic changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)