### PR TITLE
feat: add training plan and workout calculation features

### DIFF
--- a/coros_api.py
+++ b/coros_api.py
@@ -47,7 +47,9 @@ ENDPOINTS = {
     "activity_detail": "/activity/detail/query",
     "sport_types": "/activity/fit/getImportSportList",
     "workout_list": "/training/program/query",  # POST — list/fetch workout programs
+    "plan_list": "/training/plan/query",  # POST — list training plans
     "workout_add": "/training/program/add",     # POST — create new structured workout
+    "workout_calculate": "/training/program/calculate",  # POST — recalculate distance/time/load/chart
     "workout_delete": "/training/program/delete",  # POST — delete workout(s), body: ["id1", ...]
     "schedule_sum": "/training/schedule/querysum",  # GET — planned calendar aggregates
     "schedule": "/training/schedule/query",         # GET — planned calendar detail
@@ -629,6 +631,69 @@ async def fetch_workouts(auth: StoredAuth) -> list[dict]:
     return [_parse_workout(w) for w in body.get("data", [])]
 
 
+def _parse_training_plan(item: dict) -> dict:
+    programs = item.get("programs", [])
+    entities = item.get("entities", [])
+    return {
+        "id": str(item.get("id", "")),
+        "name": item.get("name"),
+        "overview": item.get("overview"),
+        "status": item.get("status"),
+        "execute_status": item.get("executeStatus"),
+        "start_day": item.get("startDay"),
+        "end_day": item.get("endDay"),
+        "total_day": item.get("totalDay"),
+        "min_weeks": item.get("minWeeks"),
+        "max_weeks": item.get("maxWeeks"),
+        "program_count": len(programs),
+        "entity_count": len(entities),
+    }
+
+
+async def fetch_training_plans(
+    auth: StoredAuth,
+    status_list: list[int] | None = None,
+) -> list[dict]:
+    """List user training plans."""
+    payload = {"statusList": status_list or [1, 2]}
+    params = {"teamId": "", "userId": ""}
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["plan_list"],
+            params=params,
+            json=payload,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    _check_response(body, "training plan list")
+
+    return [_parse_training_plan(p) for p in body.get("data", [])]
+
+
+async def fetch_training_plans_raw(
+    auth: StoredAuth,
+    status_list: list[int] | None = None,
+) -> list[dict]:
+    """List user training plans without stripping API fields."""
+    payload = {"statusList": status_list or [1, 2]}
+    params = {"teamId": "", "userId": ""}
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["plan_list"],
+            params=params,
+            json=payload,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    _check_response(body, "training plan list")
+
+    return body.get("data", [])
+
+
 async def create_workout(
     auth: StoredAuth,
     name: str,
@@ -805,6 +870,94 @@ async def fetch_schedule(
     _check_response(body, "schedule")
 
     return _strip_schedule(body.get("data") or {})
+
+
+async def fetch_schedule_raw(
+    auth: StoredAuth, start_day: str, end_day: str
+) -> dict:
+    """
+    Fetch planned activities without stripping fields.
+
+    Raw schedule payloads are needed when updating an existing planned workout:
+    /training/schedule/update expects the full entity/program objects, including
+    planId, planProgramId, idInPlan, exerciseBarChart, and version fields.
+    """
+    params = {
+        "startDate": start_day,
+        "endDate": end_day,
+        "supportRestExercise": 1,
+    }
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.get(
+            _base_url(auth.region) + ENDPOINTS["schedule"],
+            params=params,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    _check_response(body, "schedule")
+
+    return body.get("data") or {}
+
+
+async def calculate_workout_program(auth: StoredAuth, program: dict) -> dict:
+    """
+    Recalculate a workout program after edits.
+
+    Mirrors the Training Hub /training/program/calculate request captured from
+    the web app. The response updates derived fields such as duration,
+    estimatedDistance, estimatedValue/trainingLoad, and exerciseBarChart.
+    """
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["workout_calculate"],
+            json=program,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    _check_response(body, "workout calculate")
+
+    return body.get("data") if body.get("data") is not None else body
+
+
+def apply_workout_calculation(program: dict, calculation: dict) -> dict:
+    """
+    Return a copy of program with calculate() derived fields applied.
+
+    The calculate endpoint returns plan* fields rather than the original program
+    field names. Training Hub writes those values back onto the program before
+    sending /training/schedule/update.
+    """
+    updated = dict(program)
+
+    if (value := calculation.get("exerciseBarChart")) is not None:
+        updated["exerciseBarChart"] = value
+
+    if (value := calculation.get("planDuration")) is not None:
+        updated["duration"] = value
+        updated["estimatedTime"] = value
+
+    if (value := calculation.get("planTrainingLoad")) is not None:
+        updated["trainingLoad"] = value
+        updated["estimatedValue"] = value
+
+    if (value := calculation.get("planElevGain")) is not None:
+        updated["elevGain"] = value
+
+    if (value := calculation.get("planDistance")) is not None:
+        updated["distance"] = value
+        with contextlib.suppress(TypeError, ValueError):
+            updated["estimatedDistance"] = int(float(value))
+
+    if (value := calculation.get("planSets")) is not None and "sets" in updated:
+        updated["sets"] = value
+    if (value := calculation.get("planHybridTotalSets")) is not None and "totalSets" in updated:
+        updated["totalSets"] = value
+
+    return updated
 
 
 _EXERCISE_DROP = frozenset({
@@ -1075,6 +1228,87 @@ async def schedule_workout(
         "pbVersion": 2,
     }
 
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["schedule_update"],
+            json=payload,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    _check_response(body, "schedule update")
+
+
+async def add_planned_workout(
+    auth: StoredAuth,
+    entity: dict,
+    program: dict,
+    version_object: dict | None = None,
+) -> None:
+    """
+    Add a planned workout to the training calendar from a raw entity/program.
+
+    This mirrors the Training Hub schedule/update payload used when adding an
+    inline workout that is not first fetched from the workout library.
+    """
+    id_in_plan = entity.get("idInPlan") or program.get("idInPlan")
+    if id_in_plan is None:
+        raise ValueError("entity/program must include idInPlan for schedule add")
+
+    program.setdefault("idInPlan", id_in_plan)
+    payload = {
+        "entities": [entity],
+        "programs": [program],
+        "versionObjects": [version_object or {"id": id_in_plan, "status": 1}],
+        "pbVersion": 2,
+    }
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            _base_url(auth.region) + ENDPOINTS["schedule_update"],
+            json=payload,
+            headers=_auth_headers(auth),
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+    _check_response(body, "schedule update")
+
+
+async def update_scheduled_workout(
+    auth: StoredAuth,
+    entity: dict,
+    program: dict,
+    version_object: dict | None = None,
+) -> None:
+    """
+    Update an existing planned workout on the training calendar.
+
+    This uses the same /training/schedule/update endpoint as scheduling and
+    deletion, but sends versionObjects.status=2. The entity/program should come
+    from fetch_schedule_raw(), with any intended edits applied. If the program
+    content changes, call calculate_workout_program() first and pass the
+    calculated program here.
+    """
+    id_in_plan = str(entity.get("idInPlan") or program.get("idInPlan") or "")
+    plan_id = str(entity.get("planId") or program.get("planId") or "")
+    plan_program_id = str(entity.get("planProgramId") or program.get("planProgramId") or "")
+    if not id_in_plan or not plan_id:
+        raise ValueError("entity/program must include idInPlan and planId for schedule update")
+
+    payload = {
+        "entities": [entity],
+        "programs": [program],
+        "versionObjects": [
+            version_object or {
+                "id": id_in_plan,
+                "status": 2,
+                "planProgramId": plan_program_id,
+                "planId": plan_id,
+            }
+        ],
+        "pbVersion": 2,
+    }
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
             _base_url(auth.region) + ENDPOINTS["schedule_update"],

--- a/server.py
+++ b/server.py
@@ -96,10 +96,16 @@ async def get_help() -> dict:
             {"name": "list_activities", "description": "List recorded activities (runs, rides, swims, etc.) with summaries"},  # noqa: E501
             {"name": "get_activity_detail", "description": "Get full detail for one activity by label_id"},
             {"name": "list_workouts", "description": "List planned structured workouts saved in the Coros Training Hub"},  # noqa: E501
+            {"name": "list_training_plans", "description": "List training plans saved in the Coros Training Hub"},  # noqa: E501
+            {"name": "list_training_plans_raw", "description": "List raw training plans including entities and programs"},  # noqa: E501
             {"name": "create_workout", "description": "Create a new structured workout with intervals and steps"},
             {"name": "delete_workout", "description": "Delete a workout by workout_id"},
             {"name": "list_planned_activities", "description": "List workouts scheduled on the training calendar"},
+            {"name": "list_planned_activities_raw", "description": "List raw scheduled workouts for calendar update workflows"},  # noqa: E501
+            {"name": "calculate_workout_program", "description": "Recalculate edited workout program metrics before updating"},  # noqa: E501
             {"name": "schedule_workout", "description": "Schedule a workout on a specific date"},
+            {"name": "add_planned_workout", "description": "Add an inline planned workout to the training calendar"},  # noqa: E501
+            {"name": "update_scheduled_workout", "description": "Update an existing scheduled workout on the calendar"},  # noqa: E501
             {"name": "remove_scheduled_workout", "description": "Remove a workout from the training calendar"},
             {"name": "create_strength_workout", "description": "Create a strength/gym workout with exercises and sets"},
             {"name": "list_exercises", "description": "List available strength exercises (used when building strength workouts)"},  # noqa: E501
@@ -474,6 +480,61 @@ async def list_workouts() -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool: list_training_plans
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def list_training_plans(
+    status_list: list[int] | None = None,
+) -> dict:
+    """
+    List training plans in the Coros account.
+
+    Parameters
+    ----------
+    status_list : list[int] | None
+        Plan status values to query. Defaults to [1, 2], matching the Training
+        Hub request.
+
+    Returns
+    -------
+    dict with keys: plans (list), count
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED, "plans": []}
+    try:
+        plans = await _run_with_auth(coros_api.fetch_training_plans, auth, status_list)
+        return {"plans": plans, "count": len(plans)}
+    except Exception as exc:
+        return {"error": str(exc), "plans": []}
+
+
+# ---------------------------------------------------------------------------
+# Tool: list_training_plans_raw
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def list_training_plans_raw(
+    status_list: list[int] | None = None,
+) -> dict:
+    """
+    List training plans without stripping API fields.
+
+    Use this when the full plan payload is needed, including entities and
+    programs.
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED, "plans": []}
+    try:
+        plans = await _run_with_auth(coros_api.fetch_training_plans_raw, auth, status_list)
+        return {"plans": plans, "count": len(plans)}
+    except Exception as exc:
+        return {"error": str(exc), "plans": []}
+
+
+# ---------------------------------------------------------------------------
 # Tool: create_workout
 # ---------------------------------------------------------------------------
 
@@ -619,6 +680,60 @@ async def list_planned_activities(
 
 
 # ---------------------------------------------------------------------------
+# Tool: list_planned_activities_raw
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def list_planned_activities_raw(
+    start_day: str,
+    end_day: str,
+) -> dict:
+    """
+    List planned activities without stripping API fields.
+
+    Use this before updating an existing scheduled workout. The raw entity and
+    program objects contain identifiers and version fields required by
+    update_scheduled_workout.
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED, "schedule": {}}
+    try:
+        items = await _run_with_auth(coros_api.fetch_schedule_raw, auth, start_day, end_day)
+        return {
+            "schedule": items,
+            "count": len(items.get("entities", [])),
+            "date_range": f"{start_day} – {end_day}",
+        }
+    except Exception as exc:
+        return {"error": str(exc), "schedule": {}}
+
+
+# ---------------------------------------------------------------------------
+# Tool: calculate_workout_program
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def calculate_workout_program(program: dict) -> dict:
+    """
+    Recalculate a workout program after editing its exercises.
+
+    This calls Coros /training/program/calculate and returns the calculated
+    metrics plus a copy of the supplied program with derived fields such as
+    duration, estimated distance, training load, and exerciseBarChart applied.
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED}
+    try:
+        calculation = await _run_with_auth(coros_api.calculate_workout_program, auth, program)
+        updated_program = coros_api.apply_workout_calculation(program, calculation)
+        return {"calculation": calculation, "program": updated_program}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
 # Tool: schedule_workout
 # ---------------------------------------------------------------------------
 
@@ -652,6 +767,82 @@ async def schedule_workout(
         return {"scheduled": True, "workout_id": workout_id, "happen_day": happen_day}
     except Exception as exc:
         return {"error": str(exc), "scheduled": False}
+
+
+# ---------------------------------------------------------------------------
+# Tool: add_planned_workout
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def add_planned_workout(
+    entity: dict,
+    program: dict,
+    version_object: dict | None = None,
+) -> dict:
+    """
+    Add an inline planned workout to the Coros training calendar.
+
+    Parameters
+    ----------
+    entity : dict
+        Raw schedule entity object. Must include idInPlan and happenDay.
+    program : dict
+        Raw program object to add to the calendar.
+    version_object : dict | None
+        Optional explicit version object. If omitted, it is built with
+        status=1 (add).
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED, "added": False}
+    try:
+        await _run_with_auth(coros_api.add_planned_workout, auth, entity, program, version_object)
+        return {
+            "added": True,
+            "happen_day": entity.get("happenDay"),
+            "id_in_plan": entity.get("idInPlan") or program.get("idInPlan"),
+        }
+    except Exception as exc:
+        return {"error": str(exc), "added": False}
+
+
+# ---------------------------------------------------------------------------
+# Tool: update_scheduled_workout
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def update_scheduled_workout(
+    entity: dict,
+    program: dict,
+    version_object: dict | None = None,
+) -> dict:
+    """
+    Update an existing scheduled workout on the Coros training calendar.
+
+    Parameters
+    ----------
+    entity : dict
+        Raw entity object from list_planned_activities_raw, with any intended
+        edits applied.
+    program : dict
+        Raw or calculated program object. If exercises changed, first call
+        calculate_workout_program and pass its returned program here.
+    version_object : dict | None
+        Optional explicit version object. If omitted, it is built from entity /
+        program with status=2 (update).
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED, "updated": False}
+    try:
+        await _run_with_auth(coros_api.update_scheduled_workout, auth, entity, program, version_object)
+        return {
+            "updated": True,
+            "plan_id": entity.get("planId") or program.get("planId"),
+            "id_in_plan": entity.get("idInPlan") or program.get("idInPlan"),
+        }
+    except Exception as exc:
+        return {"error": str(exc), "updated": False}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_today_review_fixes.py
+++ b/tests/test_today_review_fixes.py
@@ -86,6 +86,50 @@ class TestParseActivityZeroValues:
         assert a.elevation_gain is None
 
 
+class TestApplyWorkoutCalculation:
+    """Schedule update flow: calculate() fields are mapped back to program fields."""
+
+    def test_calculation_updates_program_copy(self):
+        from coros_api import apply_workout_calculation
+
+        program = {
+            "duration": 100,
+            "estimatedTime": 100,
+            "estimatedValue": 10,
+            "trainingLoad": 10,
+            "distance": "1000.00",
+            "estimatedDistance": 1000,
+            "elevGain": 1,
+            "sets": 1,
+            "totalSets": 1,
+            "exerciseBarChart": [],
+        }
+        calculation = {
+            "planDuration": 200,
+            "planTrainingLoad": 30,
+            "planDistance": "2500.00",
+            "planElevGain": 5,
+            "planSets": 2,
+            "planHybridTotalSets": 3,
+            "exerciseBarChart": [{"exerciseId": "1"}],
+        }
+
+        updated = apply_workout_calculation(program, calculation)
+
+        assert updated is not program
+        assert updated["duration"] == 200
+        assert updated["estimatedTime"] == 200
+        assert updated["trainingLoad"] == 30
+        assert updated["estimatedValue"] == 30
+        assert updated["distance"] == "2500.00"
+        assert updated["estimatedDistance"] == 2500
+        assert updated["elevGain"] == 5
+        assert updated["sets"] == 2
+        assert updated["totalSets"] == 3
+        assert updated["exerciseBarChart"] == [{"exerciseId": "1"}]
+        assert program["duration"] == 100
+
+
 # ---------------------------------------------------------------------------
 # 2. Bridge warning — logged when fetch range is extended for contiguity
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Introduced new API endpoints for listing training plans and calculating workout metrics.
- Added functions to fetch training plans, both stripped and raw, and to apply calculated metrics back to workout programs.
- Updated server tools to include new functionalities for managing training plans and scheduled workouts.
- Enhanced test coverage for the new calculation logic to ensure correct mapping of derived fields.