### PR TITLE
feat: inline workout scheduling; library tools renamed to *_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,59 @@ Save a reusable cycling/intervals workout **template** to the Coros library. The
 
 Returns: `workout_id`, `name`, `total_minutes`, `steps_count`, `message`
 
+### `save_strength_workout_template`
+
+Save a reusable strength workout **template** to the Coros library. Exercises must come from the Coros exercise catalogue.
+
+> ⚠️ This persists to the library indefinitely. For a one-off workout for a specific date, use [`schedule_strength_workout`](#schedule_strength_workout) instead — it builds the workout inline and leaves no library entry.
+
+```json
+{
+  "name": "Leg Circuit",
+  "sets": 3,
+  "exercises": [
+    {
+      "origin_id": "54",
+      "name": "T1061",
+      "overview": "sid_strength_squats",
+      "target_type": 3,
+      "target_value": 12,
+      "rest_seconds": 45,
+      "sets": 3,
+      "weight_kg": 80
+    },
+    {
+      "origin_id": "130",
+      "name": "T1176",
+      "overview": "sid_strength_plank",
+      "target_type": 2,
+      "target_value": 60,
+      "rest_seconds": 30
+    }
+  ]
+}
+```
+
+`target_type`: `2` = time in seconds, `3` = reps
+
+`sets` (per exercise, optional): consecutive sets of that exercise before moving on. Use this instead of duplicating the exercise entry. Defaults to 1.
+
+`sets` (top-level): full-circuit repetitions — repeats the entire exercise list. Defaults to 1.
+
+**Weight fields (per exercise, optional):**
+
+| Field | Description |
+|-------|-------------|
+| `weight_kg` | Prescribed weight in kg (e.g. `80`) |
+| `weight_lbs` | Prescribed weight in pounds (e.g. `176.4`) — mutually exclusive with `weight_kg` |
+
+- Omitting **both** fields renders the exercise as **Bodyweight** in the Coros app.
+- Setting `weight_kg: 0` renders as **"0.00 kg"** — distinct from Bodyweight.
+- For dumbbell exercises, the weight is per hand by convention (the app shows a single value).
+- kg and lbs can be mixed across exercises within the same workout.
+
+Returns: `workout_id`, `name`, `sets`, `exercise_count`
+
 ### `delete_workout_template`
 
 Delete a saved workout template from the Coros library.
@@ -397,59 +450,6 @@ Remove a scheduled workout from the Coros training calendar.
 `plan_id`, `id_in_plan`, and `plan_program_id` come from `list_planned_activities`. If `plan_program_id` is missing, you can usually reuse `id_in_plan`.
 
 Returns: `removed`, `plan_id`, `id_in_plan`
-
-### `save_strength_workout_template`
-
-Save a reusable strength workout **template** to the Coros library. Exercises must come from the Coros exercise catalogue.
-
-> ⚠️ This persists to the library indefinitely. For a one-off workout for a specific date, use [`schedule_strength_workout`](#schedule_strength_workout) instead — it builds the workout inline and leaves no library entry.
-
-```json
-{
-  "name": "Leg Circuit",
-  "sets": 3,
-  "exercises": [
-    {
-      "origin_id": "54",
-      "name": "T1061",
-      "overview": "sid_strength_squats",
-      "target_type": 3,
-      "target_value": 12,
-      "rest_seconds": 45,
-      "sets": 3,
-      "weight_kg": 80
-    },
-    {
-      "origin_id": "130",
-      "name": "T1176",
-      "overview": "sid_strength_plank",
-      "target_type": 2,
-      "target_value": 60,
-      "rest_seconds": 30
-    }
-  ]
-}
-```
-
-`target_type`: `2` = time in seconds, `3` = reps
-
-`sets` (per exercise, optional): consecutive sets of that exercise before moving on. Use this instead of duplicating the exercise entry. Defaults to 1.
-
-`sets` (top-level): full-circuit repetitions — repeats the entire exercise list. Defaults to 1.
-
-**Weight fields (per exercise, optional):**
-
-| Field | Description |
-|-------|-------------|
-| `weight_kg` | Prescribed weight in kg (e.g. `80`) |
-| `weight_lbs` | Prescribed weight in pounds (e.g. `176.4`) — mutually exclusive with `weight_kg` |
-
-- Omitting **both** fields renders the exercise as **Bodyweight** in the Coros app.
-- Setting `weight_kg: 0` renders as **"0.00 kg"** — distinct from Bodyweight.
-- For dumbbell exercises, the weight is per hand by convention (the app shows a single value).
-- kg and lbs can be mixed across exercises within the same workout.
-
-Returns: `workout_id`, `name`, `sets`, `exercise_count`
 
 ### `list_exercises`
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ Ask your AI assistant questions like:
 | `get_sleep_data` | Fetch nightly sleep stages (deep, light, REM, awake) and sleep HR for n weeks (default: 4) |
 | `list_activities` | List activities for a date range with summary metrics |
 | `get_activity_detail` | Fetch full detail for a single activity (laps, HR zones, power zones) |
-| `list_workouts` | List all saved structured workout programs |
-| `create_workout` | Create a new structured workout with named steps and power targets |
-| `delete_workout` | Delete a workout program from the library |
+| `list_workout_templates` | List reusable workout templates saved in the library |
+| `save_workout_template` | Save a reusable cycling/intervals workout template (named steps, power targets) |
+| `save_strength_workout_template` | Save a reusable strength workout template (sets, reps, or timed exercises) |
+| `delete_workout_template` | Delete a saved workout template from the library |
 | `list_planned_activities` | List planned workouts from the Coros training calendar |
-| `schedule_workout` | Schedule an existing workout on a calendar day |
+| `schedule_workout` | Schedule a one-off cycling/intervals workout for a date (no library entry) |
+| `schedule_strength_workout` | Schedule a one-off strength workout for a date (no library entry) |
+| `schedule_workout_template` | Schedule an existing library template on a calendar day |
 | `remove_scheduled_workout` | Remove a scheduled workout from the calendar |
-| `create_strength_workout` | Create a structured strength workout with sets, reps, or timed exercises |
 | `list_exercises` | Browse the Coros exercise catalogue, especially for strength workouts |
 | `sync_coros_data` | Backfill all data into the local SQLite cache for a date range |
 | `get_cache_status` | Show coverage (record counts and date ranges) of the local cache |
@@ -255,9 +257,9 @@ Returns full activity data including laps, HR zones, power zones, and all sport-
 
 > **Note:** Large time-series arrays (`graphList`, `frequencyList`, `gpsLightDuration`) are stripped from the response to keep it manageable.
 
-### `list_workouts`
+### `list_workout_templates`
 
-List all saved structured workout programs.
+List reusable workout templates saved in the Coros library.
 
 ```json
 {}
@@ -265,11 +267,13 @@ List all saved structured workout programs.
 
 Returns: `workouts` (list), `count`
 
-Each workout includes: `id`, `name`, `sport_type`, `sport_name`, `estimated_time_seconds`, `exercise_count`, `exercises` (list of steps with `name`, `duration_seconds`, `intensity_low`, `intensity_high`, `sets`)
+Each entry includes: `id`, `name`, `sport_type`, `sport_name`, `estimated_time_seconds`, `exercise_count`, `exercises` (list of steps with `name`, `duration_seconds`, `intensity_low`, `intensity_high`, `sets`)
 
-### `create_workout`
+### `save_workout_template`
 
-Create a new structured workout. Workouts appear in the Coros app and can be synced to the watch. Steps can be plain steps or repeat groups for intervals.
+Save a reusable cycling/intervals workout **template** to the Coros library. The template appears in the Coros app and can be synced to the watch. Steps can be plain steps or repeat groups for intervals.
+
+> ⚠️ This persists to the library indefinitely. For a one-off workout for a specific date, use [`schedule_workout`](#schedule_workout) instead — it builds the workout inline and leaves no library entry.
 
 **Plain steps:**
 
@@ -308,15 +312,15 @@ Create a new structured workout. Workouts appear in the Coros app and can be syn
 
 Returns: `workout_id`, `name`, `total_minutes`, `steps_count`, `message`
 
-### `delete_workout`
+### `delete_workout_template`
 
-Delete a workout program from the Coros account.
+Delete a saved workout template from the Coros library.
 
 ```json
 { "workout_id": "476023839273435149" }
 ```
 
-The `workout_id` comes from `list_workouts`.
+The `workout_id` comes from `list_workout_templates`.
 
 Returns: `deleted`, `workout_id`, `message`
 
@@ -332,13 +336,51 @@ Returns: `schedule` (dict with `entities` and `programs` sub-lists), `count` (nu
 
 ### `schedule_workout`
 
-Add an existing workout from your library to the Coros training calendar.
+Schedule a **one-off** cycling/intervals workout for a specific date. Builds the workout inline and posts straight to the calendar — does **not** create a library entry. This is the common case.
+
+Same parameters as [`save_workout_template`](#save_workout_template), plus `happen_day` (YYYYMMDD) and an optional `sort_no` (order within the day).
+
+```json
+{
+  "name": "Z2 Recovery",
+  "happen_day": "20260312",
+  "sport_type": 2,
+  "steps": [
+    {"name": "Easy spin", "duration_minutes": 60, "intensity_low": 150, "intensity_high": 200}
+  ]
+}
+```
+
+Returns: `scheduled`, `name`, `happen_day`, `total_minutes`, `steps_count`, `response`
+
+### `schedule_strength_workout`
+
+Schedule a **one-off** strength workout for a specific date. Builds the workout inline and posts straight to the calendar — does **not** create a library entry.
+
+Same parameters as [`save_strength_workout_template`](#save_strength_workout_template), plus `happen_day`.
+
+```json
+{
+  "name": "Push Day",
+  "happen_day": "20260312",
+  "sets": 1,
+  "exercises": [ ... ]
+}
+```
+
+Returns: `scheduled`, `name`, `happen_day`, `sets`, `exercise_count`, `response`
+
+### `schedule_workout_template`
+
+Schedule an existing library template on a calendar day.
 
 ```json
 { "workout_id": "1234567890", "happen_day": "20260312", "sort_no": 1 }
 ```
 
-Returns: `scheduled`, `workout_id`, `happen_day`
+The `workout_id` comes from `list_workout_templates`. For one-off workouts that don't need a library entry, use [`schedule_workout`](#schedule_workout) or [`schedule_strength_workout`](#schedule_strength_workout) instead.
+
+Returns: `scheduled`, `workout_id`, `happen_day`, `response`
 
 ### `remove_scheduled_workout`
 
@@ -356,9 +398,11 @@ Remove a scheduled workout from the Coros training calendar.
 
 Returns: `removed`, `plan_id`, `id_in_plan`
 
-### `create_strength_workout`
+### `save_strength_workout_template`
 
-Create a structured strength workout with repeated sets. Exercises must come from the Coros exercise catalogue.
+Save a reusable strength workout **template** to the Coros library. Exercises must come from the Coros exercise catalogue.
+
+> ⚠️ This persists to the library indefinitely. For a one-off workout for a specific date, use [`schedule_strength_workout`](#schedule_strength_workout) instead — it builds the workout inline and leaves no library entry.
 
 ```json
 {

--- a/coros_api.py
+++ b/coros_api.py
@@ -613,8 +613,8 @@ def _parse_workout(item: dict) -> dict:
     }
 
 
-async def fetch_workouts(auth: StoredAuth) -> list[dict]:
-    """List all user workout programs."""
+async def fetch_workout_templates(auth: StoredAuth) -> list[dict]:
+    """List all reusable workout templates in the user's library."""
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
             _base_url(auth.region) + ENDPOINTS["workout_list"],
@@ -790,33 +790,43 @@ async def delete_workout_template(auth: StoredAuth, workout_id: str) -> None:
 # Planned activities (training schedule calendar)
 # ---------------------------------------------------------------------------
 
+async def _fetch_schedule_data(
+    client: httpx.AsyncClient,
+    auth: StoredAuth,
+    start_day: str,
+    end_day: str,
+) -> dict:
+    """Shared GET for /training/schedule/query. Returns the raw 'data' dict
+    (no stripping). Takes a caller-provided client so internal flows can
+    reuse a connection across multiple round-trips."""
+    params = {
+        "startDate": start_day,
+        "endDate": end_day,
+        "supportRestExercise": 1,
+    }
+    resp = await client.get(
+        _base_url(auth.region) + ENDPOINTS["schedule"],
+        params=params,
+        headers=_auth_headers(auth),
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    _check_response(body, "schedule")
+    return body.get("data") or {}
+
+
 async def fetch_schedule(
     auth: StoredAuth, start_day: str, end_day: str
 ) -> dict:
     """
     Fetch planned activities from the Coros training calendar.
 
-    Uses GET /training/schedule/querysum with startDate/endDate params.
     start_day / end_day: YYYYMMDD strings.
-    Returns the raw list of scheduled items.
+    Returns the stripped schedule dict.
     """
-    params = {
-        "startDate": start_day,
-        "endDate": end_day,
-        "supportRestExercise": 1,
-    }
     async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.get(
-            _base_url(auth.region) + ENDPOINTS["schedule"],
-            params=params,
-            headers=_auth_headers(auth),
-        )
-        resp.raise_for_status()
-        body = resp.json()
-
-    _check_response(body, "schedule")
-
-    return _strip_schedule(body.get("data") or {})
+        data = await _fetch_schedule_data(client, auth, start_day, end_day)
+    return _strip_schedule(data)
 
 
 _EXERCISE_DROP = frozenset({
@@ -894,19 +904,60 @@ def _strip_schedule(data: dict) -> dict:
 _LB_TO_KG = 0.45359237
 
 
+# Module-level cache for the strength-exercise catalog. The MCP server is
+# long-lived and the Coros catalog is effectively static within a session.
+# 1h TTL balances "session never refetches" with "long-running server
+# eventually picks up catalog additions if they ever happen".
+# Cache is process-global (not region/auth-scoped) — catalog IDs are global
+# across Coros regions, and the MCP server is single-user in practice.
+_STRENGTH_CATALOG_TTL_SECONDS = 3600
+_strength_catalog_cache: dict | None = None
+_strength_catalog_loaded_at: float = 0.0
+_strength_catalog_lock = asyncio.Lock()
+
+
+def _reset_strength_catalog_cache() -> None:
+    """Test-only: clear the module-level catalog cache."""
+    global _strength_catalog_cache, _strength_catalog_loaded_at
+    _strength_catalog_cache = None
+    _strength_catalog_loaded_at = 0.0
+
+
+def _catalog_is_fresh(now: float) -> bool:
+    return (
+        _strength_catalog_cache is not None
+        and now - _strength_catalog_loaded_at < _STRENGTH_CATALOG_TTL_SECONDS
+    )
+
+
 async def _load_strength_catalog(auth: StoredAuth) -> dict:
-    """Fetch the strength-exercise catalog and index by id. Returns {} on
-    transient network failure — callers treat empty as a resilient miss
-    (workout still creates, only diagram metadata is lost).
+    """Fetch the strength-exercise catalog and index by id, memoized at
+    module scope with a TTL. Returns {} on transient network failure —
+    callers treat empty as a resilient miss (workout still creates, only
+    diagram metadata is lost).
 
     Auth and API-level errors (ValueError from _check_response) propagate
     so the user learns about a broken token instead of silently getting a
-    workout without metadata."""
-    try:
-        catalog = await fetch_exercises(auth, 4)
-        return {str(e.get("id")): e for e in catalog}
-    except httpx.HTTPError:
-        return {}
+    workout without metadata.
+    """
+    global _strength_catalog_cache, _strength_catalog_loaded_at
+    if _catalog_is_fresh(time.monotonic()):
+        return _strength_catalog_cache  # type: ignore[return-value]
+
+    async with _strength_catalog_lock:
+        # Re-check inside the lock — another coroutine may have populated
+        # the cache while we were waiting.
+        if _catalog_is_fresh(time.monotonic()):
+            return _strength_catalog_cache  # type: ignore[return-value]
+
+        try:
+            catalog = await fetch_exercises(auth, 4)
+        except httpx.HTTPError:
+            # Don't cache failures — leave cache unset so a later call retries.
+            return {}
+        _strength_catalog_cache = {str(e.get("id")): e for e in catalog}
+        _strength_catalog_loaded_at = time.monotonic()
+        return _strength_catalog_cache
 
 
 def _build_strength_program_payload(
@@ -1143,37 +1194,25 @@ async def _post_schedule_inline(
     sort_no: int = 1,
 ) -> dict:
     """Resolve next idInPlan + POST /training/schedule/update with the program
-    embedded inline. Returns the response 'data' dict so callers can surface
-    server-assigned identifiers (plan_id, id_in_plan, plan_program_id).
+    embedded inline, then GET the schedule again to surface server-assigned
+    identifiers. Returns a 4-key dict: plan_id, id_in_plan, plan_program_id,
+    entity_id (all strings). On enrichment failure the schedule POST has
+    already succeeded — only id_in_plan is populated, the other three are
+    empty strings.
 
     maxIdInPlan + 1 is racy under concurrent calls — pre-existing behavior.
     """
-    params = {
-        "startDate": happen_day,
-        "endDate": happen_day,
-        "supportRestExercise": 1,
-    }
     async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.get(
-            _base_url(auth.region) + ENDPOINTS["schedule"],
-            params=params,
-            headers=_auth_headers(auth),
-        )
-        resp.raise_for_status()
-        schedule_body = resp.json()
-
-        raw_data = schedule_body.get("data") or {}
+        pre_data = await _fetch_schedule_data(client, auth, happen_day, happen_day)
         try:
-            id_in_plan = int(raw_data.get("maxIdInPlan", 0)) + 1
+            id_in_plan = int(pre_data.get("maxIdInPlan", 0)) + 1
         except (TypeError, ValueError):
             id_in_plan = 1
 
         program_with_id = {**program, "idInPlan": id_in_plan}
 
-        # versionObjects + pbVersion are reverse-engineered from iOS app
-        # payloads. pbVersion=2 is the schema version Coros expects; status=1
-        # signals "active" (status=3 is the delete marker — see
-        # remove_scheduled_workout).
+        # pbVersion=2 + versionObjects status=1 reverse-engineered from iOS;
+        # status=3 is the delete marker (see remove_scheduled_workout).
         payload = {
             "entities": [{
                 "happenDay": happen_day,
@@ -1192,11 +1231,32 @@ async def _post_schedule_inline(
         )
         resp.raise_for_status()
         body = resp.json()
+        _check_response(body, "schedule update")
 
-    _check_response(body, "schedule update")
+        # schedule/update's response omits the identifiers that
+        # remove_scheduled_workout requires; re-fetch and locate our entry
+        # by client-computed idInPlan (unique within a plan). Best-effort:
+        # POST already succeeded, lookup failure must not propagate as a
+        # schedule failure.
+        result = {
+            "plan_id": "",
+            "id_in_plan": str(id_in_plan),
+            "plan_program_id": "",
+            "entity_id": "",
+        }
+        try:
+            post_data = await _fetch_schedule_data(client, auth, happen_day, happen_day)
+            for entity in post_data.get("entities") or []:
+                if str(entity.get("idInPlan", "")) == str(id_in_plan):
+                    result["plan_id"] = str(post_data.get("id", ""))
+                    result["id_in_plan"] = str(entity.get("idInPlan", id_in_plan))
+                    result["plan_program_id"] = str(entity.get("planProgramId", ""))
+                    result["entity_id"] = str(entity.get("id", ""))
+                    break
+        except (httpx.HTTPError, ValueError):
+            pass
 
-    response_data = body.get("data")
-    return response_data if isinstance(response_data, dict) else {"id_in_plan": id_in_plan}
+    return result
 
 
 async def schedule_workout_template(

--- a/coros_api.py
+++ b/coros_api.py
@@ -629,31 +629,18 @@ async def fetch_workouts(auth: StoredAuth) -> list[dict]:
     return [_parse_workout(w) for w in body.get("data", [])]
 
 
-async def create_workout(
-    auth: StoredAuth,
+def _build_workout_program_payload(
     name: str,
     steps: list[dict],
     sport_type: int = 2,
     intensity_type: int = 6,
-) -> str:
+) -> dict:
+    """Sync builder for the cycling/intervals program dict.
+
+    steps: list of dicts — either plain steps or repeat groups (see
+    save_workout_template docstring).
     """
-    Create a new structured workout program.
-
-    steps: list of dicts — either plain steps or repeat groups.
-
-    Plain step:
-      - name: str — step label (e.g. "10:00 Einfahren")
-      - duration_minutes: float — step duration in minutes
-      - intensity_low: int — lower intensity target (watts, BPM, etc. per intensity_type)
-      - intensity_high: int — upper intensity target (0 = open-ended)
-
-    Repeat group:
-      - repeat: int — number of repetitions
-      - steps: list[dict] — sub-steps (same format as plain steps)
-
-    Returns the new workout ID.
-    """
-    exercises = []
+    exercises: list[dict] = []
     top_index = 0  # counts top-level positions for sortNo
     total_seconds = 0
     ex_id = 0  # sequential exercise IDs (API uses these to link groups)
@@ -672,7 +659,6 @@ async def create_workout(
             )
             total_seconds += iteration_seconds * step["repeat"]
 
-            # Group header exercise
             exercises.append({
                 "id": group_id,
                 "name": "Group",
@@ -691,7 +677,6 @@ async def create_workout(
                 "originId": "0",
             })
 
-            # Sub-step exercises
             for j, sub in enumerate(sub_steps):
                 ex_id += 1
                 sub_duration = int(sub["duration_minutes"] * 60)
@@ -738,13 +723,40 @@ async def create_workout(
                 "originId": "0",
             })
 
-    payload = {
+    return {
         "name": name,
         "sportType": sport_type,
         "estimatedTime": total_seconds,
         "access": 1,
         "exercises": exercises,
     }
+
+
+async def save_workout_template(
+    auth: StoredAuth,
+    name: str,
+    steps: list[dict],
+    sport_type: int = 2,
+    intensity_type: int = 6,
+) -> str:
+    """
+    Save a reusable cycling/intervals workout template to the Coros library.
+
+    steps: list of dicts — either plain steps or repeat groups.
+
+    Plain step:
+      - name: str — step label (e.g. "10:00 Einfahren")
+      - duration_minutes: float — step duration in minutes
+      - intensity_low: int — lower intensity target (watts, BPM, etc. per intensity_type)
+      - intensity_high: int — upper intensity target (0 = open-ended)
+
+    Repeat group:
+      - repeat: int — number of repetitions
+      - steps: list[dict] — sub-steps (same format as plain steps)
+
+    Returns the new workout ID.
+    """
+    payload = _build_workout_program_payload(name, steps, sport_type, intensity_type)
 
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
@@ -760,8 +772,8 @@ async def create_workout(
     return str(body.get("data", ""))
 
 
-async def delete_workout(auth: StoredAuth, workout_id: str) -> None:
-    """Delete a workout program by ID."""
+async def delete_workout_template(auth: StoredAuth, workout_id: str) -> None:
+    """Delete a saved workout template by ID."""
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
             _base_url(auth.region) + ENDPOINTS["workout_delete"],
@@ -882,50 +894,42 @@ def _strip_schedule(data: dict) -> dict:
 _LB_TO_KG = 0.45359237
 
 
-async def create_strength_workout(
-    auth: StoredAuth,
-    name: str,
-    exercises: list[dict],
-    sets: int = 1,
-) -> str:
-    """
-    Create a new structured strength workout program.
+async def _load_strength_catalog(auth: StoredAuth) -> dict:
+    """Fetch the strength-exercise catalog and index by id. Returns {} on
+    transient network failure — callers treat empty as a resilient miss
+    (workout still creates, only diagram metadata is lost).
 
-    exercises: list of dicts with keys:
-      - origin_id: str  — exercise catalogue ID (from list_exercises)
-      - name: str       — T-code name (e.g. "T1061")
-      - overview: str   — sid_ key (e.g. "sid_strength_squats")
-      - target_type: int — 2=time (seconds), 3=reps
-      - target_value: int — seconds or reps
-      - rest_seconds: int — rest after this exercise. 0 → "Skip rests".
-      - weight_kg: float (optional) — prescribed weight in kg.
-      - weight_lbs: float (optional) — prescribed weight in pounds.
-        Mutually exclusive with weight_kg; pick one.
-        Omitting BOTH renders as "Bodyweight" in the app.
-        Explicit weight_kg=0 renders as "0.00 kg" — different from omitting.
-        For dumbbell exercises, by convention this is the per-hand weight.
-        The Coros app does not render ranges — single values only.
-
-    sets: number of circuit repetitions.
-
-    Returns the new workout ID.
-    """
-    if not exercises:
-        raise ValueError("create_strength_workout requires at least one exercise")
-
-    sets = max(1, sets)
-
-    # Fetch the strength catalog so we can copy per-exercise muscle / equipment /
-    # body-part metadata into each workout exercise. Without these, the Coros app
-    # cannot render the Training Machines / Training Parts sections, and the
-    # "Bodyweight" label on un-weighted exercises doesn't render either.
-    # If the catalog endpoint is down or rate-limited the workout still
-    # creates — only the diagram metadata is lost.
+    Auth and API-level errors (ValueError from _check_response) propagate
+    so the user learns about a broken token instead of silently getting a
+    workout without metadata."""
     try:
         catalog = await fetch_exercises(auth, 4)
-        by_id = {str(e.get("id")): e for e in catalog}
-    except Exception:
-        by_id = {}
+        return {str(e.get("id")): e for e in catalog}
+    except httpx.HTTPError:
+        return {}
+
+
+def _build_strength_program_payload(
+    name: str,
+    exercises: list[dict],
+    by_id: dict,
+    sets: int = 1,
+) -> dict:
+    """Sync builder for the strength program dict — the JSON body that
+    /training/program/add accepts and that schedule/update accepts inline.
+
+    by_id is the catalog lookup ({id: catalog_entry}) used to populate per-
+    exercise muscle/part/equipment metadata. Pass {} to skip catalog enrichment.
+
+    Validation (raises ValueError):
+      - empty exercises
+      - both weight_kg and weight_lbs set on the same exercise
+      - negative weight
+    """
+    if not exercises:
+        raise ValueError("strength workout requires at least one exercise")
+
+    sets = max(1, sets)
 
     built = []
     total_duration = 0
@@ -1064,6 +1068,39 @@ async def create_strength_workout(
         "videoCoverUrl": "",
         "videoUrl": "",
     }
+    return payload
+
+
+async def save_strength_workout_template(
+    auth: StoredAuth,
+    name: str,
+    exercises: list[dict],
+    sets: int = 1,
+) -> str:
+    """
+    Save a reusable strength workout template to the Coros library.
+
+    exercises: list of dicts with keys:
+      - origin_id: str  — exercise catalogue ID (from list_exercises)
+      - name: str       — T-code name (e.g. "T1061")
+      - overview: str   — sid_ key (e.g. "sid_strength_squats")
+      - target_type: int — 2=time (seconds), 3=reps
+      - target_value: int — seconds or reps
+      - rest_seconds: int — rest after this exercise. 0 → "Skip rests".
+      - weight_kg: float (optional) — prescribed weight in kg.
+      - weight_lbs: float (optional) — prescribed weight in pounds.
+        Mutually exclusive with weight_kg; pick one.
+        Omitting BOTH renders as "Bodyweight" in the app.
+        Explicit weight_kg=0 renders as "0.00 kg" — different from omitting.
+        For dumbbell exercises, by convention this is the per-hand weight.
+        The Coros app does not render ranges — single values only.
+
+    sets: number of circuit repetitions.
+
+    Returns the new workout ID.
+    """
+    by_id = await _load_strength_catalog(auth)
+    payload = _build_strength_program_payload(name, exercises, by_id, sets)
 
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
@@ -1080,7 +1117,10 @@ async def create_strength_workout(
 
 
 async def _fetch_raw_workout(auth: StoredAuth, workout_id: str) -> dict | None:
-    """Return the raw workout object for a given ID from the workout list."""
+    """Return the raw workout object for a given ID from the workout list.
+    Returns None only when the list call succeeds but the ID is absent —
+    API-level errors raise via _check_response so callers don't confuse
+    'API broke' with 'not in library'."""
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
             _base_url(auth.region) + ENDPOINTS["workout_list"],
@@ -1089,30 +1129,25 @@ async def _fetch_raw_workout(auth: StoredAuth, workout_id: str) -> dict | None:
         )
         resp.raise_for_status()
         body = resp.json()
+    _check_response(body, "workout list")
     for w in body.get("data", []):
         if str(w.get("id", "")) == str(workout_id):
             return w
     return None
 
 
-async def schedule_workout(
+async def _post_schedule_inline(
     auth: StoredAuth,
-    workout_id: str,
+    program: dict,
     happen_day: str,
     sort_no: int = 1,
-) -> None:
-    """
-    Add an existing workout to the Coros training calendar.
+) -> dict:
+    """Resolve next idInPlan + POST /training/schedule/update with the program
+    embedded inline. Returns the response 'data' dict so callers can surface
+    server-assigned identifiers (plan_id, id_in_plan, plan_program_id).
 
-    happen_day: YYYYMMDD string.
-    sort_no: order within the day (1 = first workout).
+    maxIdInPlan + 1 is racy under concurrent calls — pre-existing behavior.
     """
-    # Get raw workout object
-    program = await _fetch_raw_workout(auth, workout_id)
-    if program is None:
-        raise ValueError(f"Workout {workout_id} not found in library.")
-
-    # Fetch schedule to get maxIdInPlan (raw, not stripped)
     params = {
         "startDate": happen_day,
         "endDate": happen_day,
@@ -1127,26 +1162,29 @@ async def schedule_workout(
         resp.raise_for_status()
         schedule_body = resp.json()
 
-    raw_data = schedule_body.get("data") or {}
-    try:
-        id_in_plan = int(raw_data.get("maxIdInPlan", 0)) + 1
-    except (TypeError, ValueError):
-        id_in_plan = 1
+        raw_data = schedule_body.get("data") or {}
+        try:
+            id_in_plan = int(raw_data.get("maxIdInPlan", 0)) + 1
+        except (TypeError, ValueError):
+            id_in_plan = 1
 
-    program["idInPlan"] = id_in_plan
+        program_with_id = {**program, "idInPlan": id_in_plan}
 
-    payload = {
-        "entities": [{
-            "happenDay": happen_day,
-            "idInPlan": id_in_plan,
-            "sortNoInSchedule": sort_no,
-        }],
-        "programs": [program],
-        "versionObjects": [{"id": id_in_plan, "status": 1}],
-        "pbVersion": 2,
-    }
+        # versionObjects + pbVersion are reverse-engineered from iOS app
+        # payloads. pbVersion=2 is the schema version Coros expects; status=1
+        # signals "active" (status=3 is the delete marker — see
+        # remove_scheduled_workout).
+        payload = {
+            "entities": [{
+                "happenDay": happen_day,
+                "idInPlan": id_in_plan,
+                "sortNoInSchedule": sort_no,
+            }],
+            "programs": [program_with_id],
+            "versionObjects": [{"id": id_in_plan, "status": 1}],
+            "pbVersion": 2,
+        }
 
-    async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
             _base_url(auth.region) + ENDPOINTS["schedule_update"],
             json=payload,
@@ -1156,6 +1194,73 @@ async def schedule_workout(
         body = resp.json()
 
     _check_response(body, "schedule update")
+
+    response_data = body.get("data")
+    return response_data if isinstance(response_data, dict) else {"id_in_plan": id_in_plan}
+
+
+async def schedule_workout_template(
+    auth: StoredAuth,
+    workout_id: str,
+    happen_day: str,
+    sort_no: int = 1,
+) -> dict:
+    """
+    Add an existing library workout template to the Coros training calendar.
+
+    happen_day: YYYYMMDD string.
+    sort_no: order within the day (1 = first workout).
+
+    Returns the server response 'data' dict (shape depends on Coros API).
+    """
+    program = await _fetch_raw_workout(auth, workout_id)
+    if program is None:
+        raise ValueError(f"Workout {workout_id} not found in library.")
+    return await _post_schedule_inline(auth, program, happen_day, sort_no)
+
+
+async def schedule_workout(
+    auth: StoredAuth,
+    name: str,
+    steps: list[dict],
+    happen_day: str,
+    sport_type: int = 2,
+    intensity_type: int = 6,
+    sort_no: int = 1,
+) -> dict:
+    """
+    Build + schedule a one-off cycling/intervals workout for happen_day.
+    Does NOT persist a library entry — the program is embedded inline
+    in the schedule POST.
+
+    steps: same shape as save_workout_template (plain steps or repeat groups).
+
+    Returns the server response 'data' dict (shape depends on Coros API).
+    """
+    program = _build_workout_program_payload(name, steps, sport_type, intensity_type)
+    return await _post_schedule_inline(auth, program, happen_day, sort_no)
+
+
+async def schedule_strength_workout(
+    auth: StoredAuth,
+    name: str,
+    exercises: list[dict],
+    happen_day: str,
+    sets: int = 1,
+    sort_no: int = 1,
+) -> dict:
+    """
+    Build + schedule a one-off strength workout for happen_day. Does NOT
+    persist a library entry — the program is embedded inline in the
+    schedule POST.
+
+    exercises: same shape as save_strength_workout_template. Empty list raises.
+
+    Returns the server response 'data' dict (shape depends on Coros API).
+    """
+    by_id = await _load_strength_catalog(auth)
+    program = _build_strength_program_payload(name, exercises, by_id, sets)
+    return await _post_schedule_inline(auth, program, happen_day, sort_no)
 
 
 async def remove_scheduled_workout(

--- a/coros_api.py
+++ b/coros_api.py
@@ -640,6 +640,8 @@ def _build_workout_program_payload(
     steps: list of dicts — either plain steps or repeat groups (see
     save_workout_template docstring).
     """
+    if not steps:
+        raise ValueError("workout requires at least one step")
     exercises: list[dict] = []
     top_index = 0  # counts top-level positions for sortNo
     total_seconds = 0
@@ -917,7 +919,10 @@ _strength_catalog_lock = asyncio.Lock()
 
 
 def _reset_strength_catalog_cache() -> None:
-    """Test-only: clear the module-level catalog cache."""
+    """Test-only helper: clear the module-level strength-catalog cache so
+    the next call to _load_strength_catalog refetches. Not part of the
+    public API — production code has no reason to invalidate the cache
+    (process restart is the supported way to pick up catalog changes)."""
     global _strength_catalog_cache, _strength_catalog_loaded_at
     _strength_catalog_cache = None
     _strength_catalog_loaded_at = 0.0
@@ -1195,12 +1200,17 @@ async def _post_schedule_inline(
 ) -> dict:
     """Resolve next idInPlan + POST /training/schedule/update with the program
     embedded inline, then GET the schedule again to surface server-assigned
-    identifiers. Returns a 4-key dict: plan_id, id_in_plan, plan_program_id,
-    entity_id (all strings). On enrichment failure the schedule POST has
-    already succeeded — only id_in_plan is populated, the other three are
-    empty strings.
+    identifiers. Returns a 5-key dict: plan_id, id_in_plan, plan_program_id,
+    entity_id (all strings) and enrichment_ok (bool). On enrichment failure
+    the schedule POST has already succeeded — only id_in_plan is populated,
+    the other three string IDs are empty and enrichment_ok is False so the
+    caller can surface a warning instead of piping empty IDs straight into
+    remove_scheduled_workout.
 
-    maxIdInPlan + 1 is racy under concurrent calls — pre-existing behavior.
+    NOTE: idInPlan is resolved as maxIdInPlan + 1 from the pre-POST schedule
+    GET. This is racy under concurrent calls for the same happen_day —
+    pre-existing behavior, acceptable for single-user MCP. Do not call this
+    in parallel for the same date.
     """
     async with httpx.AsyncClient(timeout=30) as client:
         pre_data = await _fetch_schedule_data(client, auth, happen_day, happen_day)
@@ -1243,6 +1253,7 @@ async def _post_schedule_inline(
             "id_in_plan": str(id_in_plan),
             "plan_program_id": "",
             "entity_id": "",
+            "enrichment_ok": False,
         }
         try:
             post_data = await _fetch_schedule_data(client, auth, happen_day, happen_day)
@@ -1252,6 +1263,11 @@ async def _post_schedule_inline(
                     result["id_in_plan"] = str(entity.get("idInPlan", id_in_plan))
                     result["plan_program_id"] = str(entity.get("planProgramId", ""))
                     result["entity_id"] = str(entity.get("id", ""))
+                    result["enrichment_ok"] = bool(
+                        result["plan_id"]
+                        and result["plan_program_id"]
+                        and result["entity_id"]
+                    )
                     break
         except (httpx.HTTPError, ValueError):
             pass

--- a/server.py
+++ b/server.py
@@ -474,7 +474,7 @@ async def list_workout_templates() -> dict:
     if auth is None:
         return {"error": _NOT_AUTHENTICATED, "workouts": []}
     try:
-        workouts = await _run_with_auth(coros_api.fetch_workouts, auth)
+        workouts = await _run_with_auth(coros_api.fetch_workout_templates, auth)
         return {"workouts": workouts, "count": len(workouts)}
     except Exception as exc:
         return {"error": str(exc), "workouts": []}
@@ -672,6 +672,10 @@ async def schedule_workout_template(
     Returns
     -------
     dict with keys: scheduled, workout_id, happen_day, response
+
+    The 'response' dict contains the server-assigned identifiers needed to
+    later remove this calendar entry: plan_id, id_in_plan, plan_program_id,
+    entity_id — pipe these into remove_scheduled_workout directly.
     """
     auth = await _get_auth()
     if auth is None:
@@ -736,6 +740,10 @@ async def schedule_workout(
     Returns
     -------
     dict with keys: scheduled, name, happen_day, total_minutes, steps_count, response
+
+    The 'response' dict contains the server-assigned identifiers needed to
+    later remove this calendar entry: plan_id, id_in_plan, plan_program_id,
+    entity_id — pipe these into remove_scheduled_workout directly.
     """
     auth = await _get_auth()
     if auth is None:
@@ -810,6 +818,10 @@ async def schedule_strength_workout(
     Returns
     -------
     dict with keys: scheduled, name, happen_day, sets, exercise_count, response
+
+    The 'response' dict contains the server-assigned identifiers needed to
+    later remove this calendar entry: plan_id, id_in_plan, plan_program_id,
+    entity_id — pipe these into remove_scheduled_workout directly.
     """
     auth = await _get_auth()
     if auth is None:

--- a/server.py
+++ b/server.py
@@ -95,13 +95,15 @@ async def get_help() -> dict:
             {"name": "get_sleep_data", "description": "Fetch nightly sleep records with duration and quality score (mobile auth required for stage breakdown)"},  # noqa: E501
             {"name": "list_activities", "description": "List recorded activities (runs, rides, swims, etc.) with summaries"},  # noqa: E501
             {"name": "get_activity_detail", "description": "Get full detail for one activity by label_id"},
-            {"name": "list_workouts", "description": "List planned structured workouts saved in the Coros Training Hub"},  # noqa: E501
-            {"name": "create_workout", "description": "Create a new structured workout with intervals and steps"},
-            {"name": "delete_workout", "description": "Delete a workout by workout_id"},
+            {"name": "list_workout_templates", "description": "List reusable workout templates saved in the Coros library"},  # noqa: E501
+            {"name": "save_workout_template", "description": "Save a reusable cycling/intervals workout template to the library"},  # noqa: E501
+            {"name": "save_strength_workout_template", "description": "Save a reusable strength workout template to the library"},  # noqa: E501
+            {"name": "delete_workout_template", "description": "Delete a saved workout template by workout_id"},
             {"name": "list_planned_activities", "description": "List workouts scheduled on the training calendar"},
-            {"name": "schedule_workout", "description": "Schedule a workout on a specific date"},
+            {"name": "schedule_workout", "description": "Schedule a one-off cycling/intervals workout for a date (no library entry)"},  # noqa: E501
+            {"name": "schedule_strength_workout", "description": "Schedule a one-off strength workout for a date (no library entry)"},  # noqa: E501
+            {"name": "schedule_workout_template", "description": "Schedule an existing library workout template on a specific date"},  # noqa: E501
             {"name": "remove_scheduled_workout", "description": "Remove a workout from the training calendar"},
-            {"name": "create_strength_workout", "description": "Create a strength/gym workout with exercises and sets"},
             {"name": "list_exercises", "description": "List available strength exercises (used when building strength workouts)"},  # noqa: E501
             {"name": "sync_coros_data", "description": "Backfill local cache from the Coros API for a date range"},
             {"name": "get_cache_status", "description": "Show local cache coverage: date ranges stored for each data type"},  # noqa: E501
@@ -448,18 +450,23 @@ async def get_activity_detail(activity_id: str, sport_type: int = 0) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Tool: list_workouts
+# Tool: list_workout_templates
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def list_workouts() -> dict:
+async def list_workout_templates() -> dict:
     """
-    List all saved workout programs in the Coros account.
+    List reusable workout templates saved in the Coros library.
+
+    These are templates created by save_workout_template /
+    save_strength_workout_template — schedulable later via
+    schedule_workout_template. One-off workouts scheduled with
+    schedule_workout / schedule_strength_workout do NOT appear here.
 
     Returns
     -------
     dict with keys: workouts (list), count
-    Each workout contains: id, name, sport_type, sport_name,
+    Each entry contains: id, name, sport_type, sport_name,
     estimated_time_seconds, exercise_count, exercises (list of steps with
     name, duration_seconds, intensity_low, intensity_high, sets)
     """
@@ -474,21 +481,35 @@ async def list_workouts() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Tool: create_workout
+# Tool: save_workout_template
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def create_workout(
+async def save_workout_template(
     name: str,
     steps: list[dict],
     sport_type: int = 2,
     intensity_type: int = 6,
 ) -> dict:
     """
-    Create a new structured workout in the Coros account.
+    Save a REUSABLE cycling/intervals workout TEMPLATE to the Coros library.
 
-    The workout appears in the Coros app under Workouts and can be synced
-    to the watch for guided execution.
+    ⚠️ This persists to the library indefinitely. Use ONLY when the user
+    explicitly asks to "save as a template", "create a workout in my
+    library", "add to my workout list", or otherwise indicates they want
+    a reusable template.
+
+    For a ONE-OFF workout for a specific date — the common case — use
+    schedule_workout instead. That tool builds the workout inline and
+    leaves no library residue.
+
+    If the user's intent is unclear, ASK THEM:
+      "Do you want this saved as a reusable template in your library, or
+       just scheduled as a one-off for [date]?"
+    Don't guess.
+
+    The saved template appears in the Coros app under Workouts and can be
+    synced to the watch for guided execution.
 
     Parameters
     ----------
@@ -533,7 +554,9 @@ async def create_workout(
     if auth is None:
         return {"error": _NOT_AUTHENTICATED}
     try:
-        workout_id = await _run_with_auth(coros_api.create_workout, auth, name, steps, sport_type, intensity_type)
+        workout_id = await _run_with_auth(
+            coros_api.save_workout_template, auth, name, steps, sport_type, intensity_type
+        )
         total_minutes, steps_count = _summarize_steps(steps)
         return {
             "workout_id": workout_id,
@@ -547,20 +570,20 @@ async def create_workout(
 
 
 # ---------------------------------------------------------------------------
-# Tool: delete_workout
+# Tool: delete_workout_template
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def delete_workout(
+async def delete_workout_template(
     workout_id: str,
 ) -> dict:
     """
-    Delete a workout program from the Coros account.
+    Delete a saved workout TEMPLATE from the Coros library.
 
     Parameters
     ----------
     workout_id : str
-        The workout ID to delete (from list_workouts).
+        The workout ID to delete (from list_workout_templates).
 
     Returns
     -------
@@ -570,11 +593,11 @@ async def delete_workout(
     if auth is None:
         return {"error": _NOT_AUTHENTICATED}
     try:
-        await _run_with_auth(coros_api.delete_workout, auth, workout_id)
+        await _run_with_auth(coros_api.delete_workout_template, auth, workout_id)
         return {
             "deleted": True,
             "workout_id": workout_id,
-            "message": "Workout deleted.",
+            "message": "Workout template deleted.",
         }
     except Exception as exc:
         return {"error": str(exc)}
@@ -619,22 +642,28 @@ async def list_planned_activities(
 
 
 # ---------------------------------------------------------------------------
-# Tool: schedule_workout
+# Tool: schedule_workout_template
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def schedule_workout(
+async def schedule_workout_template(
     workout_id: str,
     happen_day: str,
     sort_no: int = 1,
 ) -> dict:
     """
-    Add an existing workout from the library to the Coros training calendar.
+    Add an existing library workout TEMPLATE to the training calendar.
+
+    Use this only when scheduling a previously-saved template by ID. For a
+    one-off workout that doesn't need to live in the library, use the
+    inline tools instead: schedule_workout (cycling/intervals) or
+    schedule_strength_workout (strength).
 
     Parameters
     ----------
     workout_id : str
-        ID of the workout to schedule (from list_workouts or create_workout).
+        ID of the workout template to schedule (from list_workout_templates,
+        save_workout_template, or save_strength_workout_template).
     happen_day : str
         Date in YYYYMMDD format.
     sort_no : int
@@ -642,14 +671,167 @@ async def schedule_workout(
 
     Returns
     -------
-    dict with keys: scheduled, workout_id, happen_day
+    dict with keys: scheduled, workout_id, happen_day, response
     """
     auth = await _get_auth()
     if auth is None:
         return {"error": _NOT_AUTHENTICATED}
     try:
-        await _run_with_auth(coros_api.schedule_workout, auth, workout_id, happen_day, sort_no)
-        return {"scheduled": True, "workout_id": workout_id, "happen_day": happen_day}
+        response = await _run_with_auth(
+            coros_api.schedule_workout_template, auth, workout_id, happen_day, sort_no
+        )
+        return {
+            "scheduled": True,
+            "workout_id": workout_id,
+            "happen_day": happen_day,
+            "response": response,
+        }
+    except Exception as exc:
+        return {"error": str(exc), "scheduled": False}
+
+
+# ---------------------------------------------------------------------------
+# Tool: schedule_workout (inline, one-off cycling/intervals)
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def schedule_workout(
+    name: str,
+    steps: list[dict],
+    happen_day: str,
+    sport_type: int = 2,
+    intensity_type: int = 6,
+    sort_no: int = 1,
+) -> dict:
+    """
+    Schedule a ONE-OFF cycling/intervals workout for a specific date.
+
+    This is the COMMON case. Use this whenever the user wants a workout
+    on a specific date and doesn't explicitly ask for a reusable template.
+    Does NOT save to the Coros library — leaves no template behind.
+
+    For a REUSABLE library template instead, use save_workout_template
+    (which saves it for re-scheduling later via schedule_workout_template).
+
+    If the user's intent is unclear, ASK THEM:
+      "Do you want this saved as a reusable template in your library, or
+       just scheduled as a one-off for [date]?"
+    Don't guess.
+
+    Parameters
+    ----------
+    name : str
+        Workout name as it should appear on the calendar.
+    steps : list[dict]
+        Same shape as save_workout_template: plain steps or repeat groups.
+    happen_day : str
+        Date in YYYYMMDD format.
+    sport_type : int
+        Sport type ID (default 2 = Indoor Cycling).
+    intensity_type : int
+        Intensity type ID (default 6 = power in watts).
+    sort_no : int
+        Order within the day (default 1).
+
+    Returns
+    -------
+    dict with keys: scheduled, name, happen_day, total_minutes, steps_count, response
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED}
+    try:
+        response = await _run_with_auth(
+            coros_api.schedule_workout,
+            auth,
+            name,
+            steps,
+            happen_day,
+            sport_type,
+            intensity_type,
+            sort_no,
+        )
+        total_minutes, steps_count = _summarize_steps(steps)
+        return {
+            "scheduled": True,
+            "name": name,
+            "happen_day": happen_day,
+            "total_minutes": total_minutes,
+            "steps_count": steps_count,
+            "response": response,
+        }
+    except Exception as exc:
+        return {"error": str(exc), "scheduled": False}
+
+
+# ---------------------------------------------------------------------------
+# Tool: schedule_strength_workout (inline, one-off strength)
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def schedule_strength_workout(
+    name: str,
+    exercises: list[dict],
+    happen_day: str,
+    sets: int = 1,
+    sort_no: int = 1,
+) -> dict:
+    """
+    Schedule a ONE-OFF strength workout for a specific date.
+
+    This is the COMMON case. Use this whenever the user wants a strength
+    workout on a specific date and doesn't explicitly ask for a reusable
+    template. Does NOT save to the Coros library — leaves no template
+    behind.
+
+    For a REUSABLE library template instead, use save_strength_workout_template
+    (which saves it for re-scheduling later via schedule_workout_template).
+
+    If the user's intent is unclear, ASK THEM:
+      "Do you want this saved as a reusable template in your library, or
+       just scheduled as a one-off for [date]?"
+    Don't guess.
+
+    Parameters
+    ----------
+    name : str
+        Workout name as it should appear on the calendar.
+    exercises : list[dict]
+        Same shape as save_strength_workout_template (origin_id, name, overview,
+        target_type, target_value, rest_seconds, optional weight_kg or
+        weight_lbs, optional per-exercise sets).
+    happen_day : str
+        Date in YYYYMMDD format.
+    sets : int
+        Number of full-circuit repetitions (default 1).
+    sort_no : int
+        Order within the day (default 1).
+
+    Returns
+    -------
+    dict with keys: scheduled, name, happen_day, sets, exercise_count, response
+    """
+    auth = await _get_auth()
+    if auth is None:
+        return {"error": _NOT_AUTHENTICATED}
+    try:
+        response = await _run_with_auth(
+            coros_api.schedule_strength_workout,
+            auth,
+            name,
+            exercises,
+            happen_day,
+            sets,
+            sort_no,
+        )
+        return {
+            "scheduled": True,
+            "name": name,
+            "happen_day": happen_day,
+            "sets": sets,
+            "exercise_count": len(exercises),
+            "response": response,
+        }
     except Exception as exc:
         return {"error": str(exc), "scheduled": False}
 
@@ -693,17 +875,30 @@ async def remove_scheduled_workout(
 
 
 # ---------------------------------------------------------------------------
-# Tool: create_strength_workout
+# Tool: save_strength_workout_template
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def create_strength_workout(
+async def save_strength_workout_template(
     name: str,
     exercises: list[dict],
     sets: int = 1,
 ) -> dict:
     """
-    Create a new structured strength workout program.
+    Save a REUSABLE strength workout TEMPLATE to the Coros library.
+
+    ⚠️ This persists to the library indefinitely. Use ONLY when the user
+    explicitly asks to "save as a template", "create a workout in my
+    library", "add to my workout list".
+
+    For a ONE-OFF workout for a specific date — the common case — use
+    schedule_strength_workout instead. That tool builds the workout inline
+    and leaves no library residue.
+
+    If the user's intent is unclear, ASK THEM:
+      "Do you want this saved as a reusable template in your library, or
+       just scheduled as a one-off for [date]?"
+    Don't guess.
 
     Parameters
     ----------
@@ -748,7 +943,7 @@ async def create_strength_workout(
     if auth is None:
         return {"error": _NOT_AUTHENTICATED}
     try:
-        workout_id = await _run_with_auth(coros_api.create_strength_workout, auth, name, exercises, sets)
+        workout_id = await _run_with_auth(coros_api.save_strength_workout_template, auth, name, exercises, sets)
         return {
             "workout_id": workout_id,
             "name": name,

--- a/server.py
+++ b/server.py
@@ -63,6 +63,24 @@ async def _run_with_auth(fn, auth, *args, **kwargs):
         return await fn(new_auth, *args, **kwargs)
 
 
+_ENRICHMENT_WARNING = (
+    "Schedule POST succeeded but enrichment GET could not resolve "
+    "plan_id/plan_program_id/entity_id. remove_scheduled_workout will not "
+    "work with this response — call list_planned_activities for the day to "
+    "look up the missing identifiers."
+)
+
+
+def _attach_enrichment_warning(result: dict, response: dict) -> dict:
+    """Add a top-level `warning` key to `result` if the inline-schedule
+    enrichment GET could not populate the server-assigned identifiers.
+    Default to False when the key is absent so a missing flag surfaces
+    as a warning (safer than silent omission)."""
+    if not response.get("enrichment_ok", False):
+        result["warning"] = _ENRICHMENT_WARNING
+    return result
+
+
 def _summarize_steps(steps: list[dict]) -> tuple[float, int]:
     """Return (total_minutes, steps_count) for a workout step list."""
     total_minutes = 0.0
@@ -671,11 +689,16 @@ async def schedule_workout_template(
 
     Returns
     -------
-    dict with keys: scheduled, workout_id, happen_day, response
+    dict with keys: scheduled, workout_id, happen_day, response, and
+    optionally 'warning' if enrichment lookup failed.
 
     The 'response' dict contains the server-assigned identifiers needed to
     later remove this calendar entry: plan_id, id_in_plan, plan_program_id,
-    entity_id — pipe these into remove_scheduled_workout directly.
+    entity_id, plus enrichment_ok. When enrichment_ok is True, pipe the
+    response into remove_scheduled_workout directly. When False, a top-level
+    'warning' key is set — the schedule POST succeeded but plan_id /
+    plan_program_id / entity_id are empty strings, so look them up via
+    list_planned_activities before calling remove_scheduled_workout.
     """
     auth = await _get_auth()
     if auth is None:
@@ -684,12 +707,15 @@ async def schedule_workout_template(
         response = await _run_with_auth(
             coros_api.schedule_workout_template, auth, workout_id, happen_day, sort_no
         )
-        return {
-            "scheduled": True,
-            "workout_id": workout_id,
-            "happen_day": happen_day,
-            "response": response,
-        }
+        return _attach_enrichment_warning(
+            {
+                "scheduled": True,
+                "workout_id": workout_id,
+                "happen_day": happen_day,
+                "response": response,
+            },
+            response,
+        )
     except Exception as exc:
         return {"error": str(exc), "scheduled": False}
 
@@ -739,11 +765,16 @@ async def schedule_workout(
 
     Returns
     -------
-    dict with keys: scheduled, name, happen_day, total_minutes, steps_count, response
+    dict with keys: scheduled, name, happen_day, total_minutes, steps_count,
+    response, and optionally 'warning' if enrichment lookup failed.
 
     The 'response' dict contains the server-assigned identifiers needed to
     later remove this calendar entry: plan_id, id_in_plan, plan_program_id,
-    entity_id — pipe these into remove_scheduled_workout directly.
+    entity_id, plus enrichment_ok. When enrichment_ok is True, pipe the
+    response into remove_scheduled_workout directly. When False, a top-level
+    'warning' key is set — the schedule POST succeeded but plan_id /
+    plan_program_id / entity_id are empty strings, so look them up via
+    list_planned_activities before calling remove_scheduled_workout.
     """
     auth = await _get_auth()
     if auth is None:
@@ -760,14 +791,17 @@ async def schedule_workout(
             sort_no,
         )
         total_minutes, steps_count = _summarize_steps(steps)
-        return {
-            "scheduled": True,
-            "name": name,
-            "happen_day": happen_day,
-            "total_minutes": total_minutes,
-            "steps_count": steps_count,
-            "response": response,
-        }
+        return _attach_enrichment_warning(
+            {
+                "scheduled": True,
+                "name": name,
+                "happen_day": happen_day,
+                "total_minutes": total_minutes,
+                "steps_count": steps_count,
+                "response": response,
+            },
+            response,
+        )
     except Exception as exc:
         return {"error": str(exc), "scheduled": False}
 
@@ -817,11 +851,16 @@ async def schedule_strength_workout(
 
     Returns
     -------
-    dict with keys: scheduled, name, happen_day, sets, exercise_count, response
+    dict with keys: scheduled, name, happen_day, sets, exercise_count,
+    response, and optionally 'warning' if enrichment lookup failed.
 
     The 'response' dict contains the server-assigned identifiers needed to
     later remove this calendar entry: plan_id, id_in_plan, plan_program_id,
-    entity_id — pipe these into remove_scheduled_workout directly.
+    entity_id, plus enrichment_ok. When enrichment_ok is True, pipe the
+    response into remove_scheduled_workout directly. When False, a top-level
+    'warning' key is set — the schedule POST succeeded but plan_id /
+    plan_program_id / entity_id are empty strings, so look them up via
+    list_planned_activities before calling remove_scheduled_workout.
     """
     auth = await _get_auth()
     if auth is None:
@@ -836,14 +875,17 @@ async def schedule_strength_workout(
             sets,
             sort_no,
         )
-        return {
-            "scheduled": True,
-            "name": name,
-            "happen_day": happen_day,
-            "sets": sets,
-            "exercise_count": len(exercises),
-            "response": response,
-        }
+        return _attach_enrichment_warning(
+            {
+                "scheduled": True,
+                "name": name,
+                "happen_day": happen_day,
+                "sets": sets,
+                "exercise_count": len(exercises),
+                "response": response,
+            },
+            response,
+        )
     except Exception as exc:
         return {"error": str(exc), "scheduled": False}
 

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -5,11 +5,18 @@ These pin the reverse-engineered encoding rules in
 Pure JSON-shape assertions — no HTTP, no auth, no mocks.
 """
 
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
 import pytest
 
+import coros_api
 from coros_api import (
     _build_strength_program_payload,
     _build_workout_program_payload,
+    _load_strength_catalog,
+    _reset_strength_catalog_cache,
 )
 
 
@@ -314,3 +321,111 @@ def test_cycling_sport_and_intensity_types_propagate():
         assert ex["sportType"] == 200
     # Non-group steps use the caller-provided intensity_type
     assert payload["exercises"][0]["intensityType"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Strength catalog cache (_load_strength_catalog)
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CATALOG = [
+    {"id": "T1010", "muscle": ["abs"], "part": ["core"], "equipment": [1]},
+    {"id": "T1052", "muscle": ["lats"], "part": ["back"], "equipment": [5]},
+    {"id": "T1120", "muscle": [], "part": [], "equipment": []},
+]
+
+
+@pytest.fixture
+def clean_catalog_cache():
+    """Reset the module-level cache before and after each test."""
+    _reset_strength_catalog_cache()
+    yield
+    _reset_strength_catalog_cache()
+
+
+async def test_catalog_cache_first_call_fetches(clean_catalog_cache, monkeypatch):
+    mock = AsyncMock(return_value=_SAMPLE_CATALOG)
+    monkeypatch.setattr(coros_api, "fetch_exercises", mock)
+
+    result = await _load_strength_catalog(auth=None)  # auth ignored by the mock
+
+    assert mock.await_count == 1
+    assert set(result.keys()) == {"T1010", "T1052", "T1120"}
+    assert result["T1052"]["muscle"] == ["lats"]
+
+
+async def test_catalog_cache_second_call_within_ttl_uses_cache(clean_catalog_cache, monkeypatch):
+    mock = AsyncMock(return_value=_SAMPLE_CATALOG)
+    monkeypatch.setattr(coros_api, "fetch_exercises", mock)
+
+    await _load_strength_catalog(auth=None)
+    await _load_strength_catalog(auth=None)
+
+    assert mock.await_count == 1
+
+
+async def test_catalog_cache_refetches_after_ttl(clean_catalog_cache, monkeypatch):
+    mock = AsyncMock(return_value=_SAMPLE_CATALOG)
+    monkeypatch.setattr(coros_api, "fetch_exercises", mock)
+
+    # First call populates cache at t=0
+    fake_now = [0.0]
+    monkeypatch.setattr(coros_api.time, "monotonic", lambda: fake_now[0])
+    await _load_strength_catalog(auth=None)
+    assert mock.await_count == 1
+
+    # Jump past TTL (1h) — next call must refetch
+    fake_now[0] = coros_api._STRENGTH_CATALOG_TTL_SECONDS + 1
+    await _load_strength_catalog(auth=None)
+    assert mock.await_count == 2
+
+
+async def test_catalog_cache_httperror_returns_empty_does_not_poison(clean_catalog_cache, monkeypatch):
+    mock = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    monkeypatch.setattr(coros_api, "fetch_exercises", mock)
+
+    result = await _load_strength_catalog(auth=None)
+    assert result == {}
+    assert coros_api._strength_catalog_cache is None
+
+    # Next call retries because cache is still unset.
+    mock.side_effect = None
+    mock.return_value = _SAMPLE_CATALOG
+    result = await _load_strength_catalog(auth=None)
+    assert set(result.keys()) == {"T1010", "T1052", "T1120"}
+    assert mock.await_count == 2
+
+
+async def test_catalog_cache_concurrent_calls_coalesce(clean_catalog_cache, monkeypatch):
+    """Five gathered calls should trigger exactly one fetch_exercises invocation.
+
+    Uses an asyncio.Event to deterministically force all five tasks to
+    queue on the cache lock before the fetch returns — without this gate
+    the first task could finish before others enter, hiding regressions
+    in the in-lock re-check branch.
+    """
+    call_count = 0
+    release_fetch = asyncio.Event()
+
+    async def gated_fetch(_auth, _sport_type):
+        nonlocal call_count
+        call_count += 1
+        await release_fetch.wait()
+        return _SAMPLE_CATALOG
+
+    monkeypatch.setattr(coros_api, "fetch_exercises", gated_fetch)
+
+    # Start five concurrent calls; they all enter _load_strength_catalog
+    # and contend for the lock. The first acquires it and stalls inside
+    # gated_fetch waiting on release_fetch.
+    tasks = [asyncio.create_task(_load_strength_catalog(auth=None)) for _ in range(5)]
+    # Yield enough to let all five tasks reach the lock-wait state.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    # Now release the fetch; cache populates, queued tasks re-check inside
+    # the lock and return the cached value without re-fetching.
+    release_fetch.set()
+    results = await asyncio.gather(*tasks)
+
+    assert call_count == 1
+    for r in results:
+        assert set(r.keys()) == {"T1010", "T1052", "T1120"}

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -1,0 +1,316 @@
+"""Tests for the strength-workout payload builder.
+
+These pin the reverse-engineered encoding rules in
+`_build_strength_program_payload` so they survive future tweaks.
+Pure JSON-shape assertions — no HTTP, no auth, no mocks.
+"""
+
+import pytest
+
+from coros_api import (
+    _build_strength_program_payload,
+    _build_workout_program_payload,
+)
+
+
+def _exercise(**overrides):
+    """Minimal exercise dict — only the keys the builder reads."""
+    base = {
+        "origin_id": "0",
+        "name": "T0000",
+        "overview": "sid_strength_test",
+        "target_type": 3,
+        "target_value": 10,
+        "rest_seconds": 60,
+    }
+    base.update(overrides)
+    return base
+
+
+def _build(exercises=None, by_id=None, sets=1):
+    if exercises is None:
+        exercises = [_exercise()]
+    if by_id is None:
+        by_id = {}
+    return _build_strength_program_payload(
+        name="test workout",
+        exercises=exercises,
+        by_id=by_id,
+        sets=sets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Weight encoding — bodyweight / kg / lbs
+# ---------------------------------------------------------------------------
+
+def test_bodyweight_omits_both():
+    payload = _build([_exercise()])
+    ex = payload["exercises"][0]
+    assert ex["intensityValue"] == ""
+    assert ex["intensityCustom"] == 1
+    assert ex["intensityDisplayUnit"] == "6"
+
+
+def test_weight_kg():
+    payload = _build([_exercise(weight_kg=27.9)])
+    ex = payload["exercises"][0]
+    assert ex["intensityValue"] == 27900
+    assert ex["intensityPercent"] == 0
+    assert ex["intensityDisplayUnit"] == "6"
+    assert ex["intensityCustom"] == 0
+    assert ex["isIntensityPercent"] is False
+
+
+def test_weight_kg_zero_renders_zero_kg():
+    """weight_kg=0 explicitly is NOT bodyweight."""
+    payload = _build([_exercise(weight_kg=0)])
+    ex = payload["exercises"][0]
+    assert ex["intensityValue"] == 0
+    assert ex["intensityCustom"] == 0
+    assert ex["intensityDisplayUnit"] == "6"
+
+
+def test_weight_lbs():
+    payload = _build([_exercise(weight_lbs=45)])
+    ex = payload["exercises"][0]
+    # 45 * 0.45359237 * 1000 = 20411.65665 → 20412
+    assert ex["intensityValue"] == 20412
+    assert ex["intensityPercent"] == 45_000_000
+    assert ex["intensityDisplayUnit"] == "7"
+    assert ex["intensityCustom"] == 0
+
+
+def test_weight_kg_and_lbs_raises():
+    with pytest.raises(ValueError):
+        _build([_exercise(weight_kg=10, weight_lbs=22)])
+
+
+def test_negative_weight_kg_raises():
+    with pytest.raises(ValueError):
+        _build([_exercise(weight_kg=-1)])
+
+
+def test_negative_weight_lbs_raises():
+    with pytest.raises(ValueError):
+        _build([_exercise(weight_lbs=-1)])
+
+
+# ---------------------------------------------------------------------------
+# Rest encoding — Skip rests vs MM:SS
+# ---------------------------------------------------------------------------
+
+def test_skip_rests_when_zero():
+    payload = _build([_exercise(rest_seconds=0)])
+    ex = payload["exercises"][0]
+    assert ex["restType"] == 3
+    assert ex["restValue"] == 0
+
+
+def test_rest_seconds_positive():
+    payload = _build([_exercise(rest_seconds=90)])
+    ex = payload["exercises"][0]
+    assert ex["restType"] == 1
+    assert ex["restValue"] == 90
+
+
+# ---------------------------------------------------------------------------
+# Per-exercise sets vs circuit sets
+# ---------------------------------------------------------------------------
+
+def test_per_exercise_sets():
+    payload = _build([_exercise(sets=3)], sets=1)
+    assert payload["exercises"][0]["sets"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Regression-pinned constants (commit cf2cec4, payload contract)
+# ---------------------------------------------------------------------------
+
+def test_status_one_on_every_exercise():
+    """Restored 2026-05-21 (commit cf2cec4) — API may treat missing as
+    disabled in the future."""
+    payload = _build([
+        _exercise(name="A"),
+        _exercise(name="B", weight_kg=10),
+        _exercise(name="C", weight_lbs=20),
+    ])
+    for ex in payload["exercises"]:
+        assert ex["status"] == 1
+
+
+def test_sport_type_4_program_and_exercise():
+    payload = _build([_exercise(), _exercise()])
+    assert payload["sportType"] == 4
+    for ex in payload["exercises"]:
+        assert ex["sportType"] == 4
+
+
+def test_exercise_num_and_total_sets():
+    payload = _build([_exercise(), _exercise(), _exercise()], sets=2)
+    assert payload["exerciseNum"] == 3
+    assert payload["totalSets"] == 2
+    assert payload["sets"] == 2
+
+
+def test_intensity_type_one_for_strength():
+    payload = _build([_exercise(), _exercise(weight_kg=10)])
+    for ex in payload["exercises"]:
+        assert ex["intensityType"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Duration math
+# ---------------------------------------------------------------------------
+
+def test_duration_per_exercise_sets():
+    """1 exercise, time target 30s + 10s rest, per-ex sets=3, circuit sets=1."""
+    payload = _build(
+        [_exercise(target_type=2, target_value=30, rest_seconds=10, sets=3)],
+        sets=1,
+    )
+    assert payload["duration"] == (30 + 10) * 3
+
+
+def test_duration_circuit_sets():
+    """1 exercise, time target 30s + 10s rest, per-ex sets=1, circuit sets=3."""
+    payload = _build(
+        [_exercise(target_type=2, target_value=30, rest_seconds=10)],
+        sets=3,
+    )
+    assert payload["duration"] == (30 + 10) * 1 * 3
+
+
+def test_duration_reps_target_excludes_value():
+    """For target_type=3 (reps), only rest counts toward duration."""
+    payload = _build(
+        [_exercise(target_type=3, target_value=12, rest_seconds=60)],
+        sets=1,
+    )
+    assert payload["duration"] == 60
+
+
+# ---------------------------------------------------------------------------
+# Catalog enrichment (Training Machines / Training Parts diagrams)
+# ---------------------------------------------------------------------------
+
+def test_catalog_metadata_propagates_when_present():
+    by_id = {
+        "T1061": {
+            "id": "T1061",
+            "muscle": ["quads", "glutes"],
+            "muscleRelevance": [1.0, 0.8],
+            "part": ["legs"],
+            "equipment": [3],
+        }
+    }
+    payload = _build([_exercise(origin_id="T1061")], by_id=by_id)
+    ex = payload["exercises"][0]
+    assert ex["muscle"] == ["quads", "glutes"]
+    assert ex["muscleRelevance"] == [1.0, 0.8]
+    assert ex["part"] == ["legs"]
+    assert ex["equipment"] == [3]
+
+
+def test_catalog_miss_gives_empty_lists():
+    """Resilience per commit b1c8328 — workout still creates, only
+    diagram metadata is lost."""
+    payload = _build([_exercise(origin_id="T9999")], by_id={})
+    ex = payload["exercises"][0]
+    assert ex["muscle"] == []
+    assert ex["muscleRelevance"] == []
+    assert ex["part"] == []
+    assert ex["equipment"] == []
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+def test_empty_exercises_raises():
+    with pytest.raises(ValueError):
+        _build(exercises=[])
+
+
+# ---------------------------------------------------------------------------
+# Cycling/intervals builder (_build_workout_program_payload)
+# ---------------------------------------------------------------------------
+
+def test_cycling_plain_steps_total_seconds():
+    payload = _build_workout_program_payload(
+        name="Z2",
+        steps=[
+            {"name": "Warmup", "duration_minutes": 10, "intensity_low": 150, "intensity_high": 200},
+            {"name": "Main",   "duration_minutes": 30, "intensity_low": 200, "intensity_high": 240},
+        ],
+    )
+    assert payload["estimatedTime"] == (10 + 30) * 60
+    assert payload["name"] == "Z2"
+    assert payload["sportType"] == 2
+    assert payload["access"] == 1
+    assert len(payload["exercises"]) == 2
+
+
+def test_cycling_repeat_group_expands_total():
+    """Repeat group: iteration_seconds * repeat is added to estimatedTime,
+    and the group header + sub-steps are all emitted (1 header + N subs)."""
+    payload = _build_workout_program_payload(
+        name="3x10",
+        steps=[
+            {"name": "Warmup", "duration_minutes": 10, "intensity_low": 150, "intensity_high": 200},
+            {"repeat": 3, "steps": [
+                {"name": "On",  "duration_minutes": 10, "intensity_low": 265, "intensity_high": 285},
+                {"name": "Off", "duration_minutes": 3,  "intensity_low": 150, "intensity_high": 175},
+            ]},
+        ],
+    )
+    # 10 + 3*(10+3) = 49 min
+    assert payload["estimatedTime"] == (10 + 3 * (10 + 3)) * 60
+    # 1 warmup + 1 group header + 2 sub-steps = 4 exercises
+    assert len(payload["exercises"]) == 4
+
+
+def test_cycling_repeat_group_links_subs_to_header():
+    """Sub-steps reference the group header via groupId; header has isGroup=True."""
+    payload = _build_workout_program_payload(
+        name="2x5",
+        steps=[
+            {"repeat": 2, "steps": [
+                {"name": "On",  "duration_minutes": 5, "intensity_low": 200, "intensity_high": 230},
+                {"name": "Off", "duration_minutes": 2, "intensity_low": 150, "intensity_high": 175},
+            ]},
+        ],
+    )
+    header, sub1, sub2 = payload["exercises"]
+    assert header["isGroup"] is True
+    assert header["sets"] == 2
+    assert sub1["isGroup"] is False
+    assert sub1["groupId"] == str(header["id"])
+    assert sub2["groupId"] == str(header["id"])
+
+
+def test_cycling_power_legacy_aliases():
+    """power_low_w / power_high_w are accepted as legacy aliases."""
+    payload = _build_workout_program_payload(
+        name="legacy",
+        steps=[
+            {"name": "Step", "duration_minutes": 5, "power_low_w": 200, "power_high_w": 240},
+        ],
+    )
+    ex = payload["exercises"][0]
+    assert ex["intensityValue"] == 200
+    assert ex["intensityValueExtend"] == 240
+
+
+def test_cycling_sport_and_intensity_types_propagate():
+    payload = _build_workout_program_payload(
+        name="hr",
+        steps=[{"name": "S", "duration_minutes": 5, "intensity_low": 140, "intensity_high": 160}],
+        sport_type=200,
+        intensity_type=2,
+    )
+    assert payload["sportType"] == 200
+    for ex in payload["exercises"]:
+        assert ex["sportType"] == 200
+    # Non-group steps use the caller-provided intensity_type
+    assert payload["exercises"][0]["intensityType"] == 2

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -309,6 +309,11 @@ def test_cycling_power_legacy_aliases():
     assert ex["intensityValueExtend"] == 240
 
 
+def test_cycling_empty_steps_raises():
+    with pytest.raises(ValueError):
+        _build_workout_program_payload(name="empty", steps=[])
+
+
 def test_cycling_sport_and_intensity_types_propagate():
     payload = _build_workout_program_payload(
         name="hr",
@@ -395,20 +400,49 @@ async def test_catalog_cache_httperror_returns_empty_does_not_poison(clean_catal
     assert mock.await_count == 2
 
 
+class _CountingLock(asyncio.Lock):
+    """asyncio.Lock that publicly counts how many tasks are currently
+    waiting on (or holding) acquire(). Used by the concurrent-coalesce
+    test to deterministically wait until N tasks are queued — without
+    poking at asyncio.Lock._waiters."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_flight = 0
+
+    async def acquire(self) -> bool:
+        self.in_flight += 1
+        try:
+            return await super().acquire()
+        except BaseException:
+            self.in_flight -= 1
+            raise
+
+    def release(self) -> None:
+        super().release()
+        self.in_flight -= 1
+
+
 async def test_catalog_cache_concurrent_calls_coalesce(clean_catalog_cache, monkeypatch):
     """Five gathered calls should trigger exactly one fetch_exercises invocation.
 
-    Uses an asyncio.Event to deterministically force all five tasks to
-    queue on the cache lock before the fetch returns — without this gate
-    the first task could finish before others enter, hiding regressions
-    in the in-lock re-check branch.
+    Uses a _CountingLock substitute so gated_fetch can deterministically
+    wait until all five tasks are queued on the cache lock before the fetch
+    returns — without this gate the first task could finish before peers
+    arrive, hiding regressions in the in-lock re-check branch.
     """
     call_count = 0
     release_fetch = asyncio.Event()
+    counting_lock = _CountingLock()
+    monkeypatch.setattr(coros_api, "_strength_catalog_lock", counting_lock)
 
     async def gated_fetch(_auth, _sport_type):
         nonlocal call_count
         call_count += 1
+        # Spin until all 5 tasks have entered _strength_catalog_lock.acquire
+        # (one holds it via us, four are queued).
+        while counting_lock.in_flight < 5:
+            await asyncio.sleep(0)
         await release_fetch.wait()
         return _SAMPLE_CATALOG
 
@@ -417,14 +451,14 @@ async def test_catalog_cache_concurrent_calls_coalesce(clean_catalog_cache, monk
     # Start five concurrent calls; they all enter _load_strength_catalog
     # and contend for the lock. The first acquires it and stalls inside
     # gated_fetch waiting on release_fetch.
-    tasks = [asyncio.create_task(_load_strength_catalog(auth=None)) for _ in range(5)]
-    # Yield enough to let all five tasks reach the lock-wait state.
-    for _ in range(10):
-        await asyncio.sleep(0)
-    # Now release the fetch; cache populates, queued tasks re-check inside
-    # the lock and return the cached value without re-fetching.
-    release_fetch.set()
-    results = await asyncio.gather(*tasks)
+    # asyncio.timeout(5) guards against regressions where _load_strength_catalog
+    # stops contending on the lock (cache short-circuit, etc.) — without it
+    # the spin in gated_fetch would hang pytest forever.
+    async with asyncio.timeout(5):
+        tasks = [asyncio.create_task(_load_strength_catalog(auth=None)) for _ in range(5)]
+        # No external sync needed: gated_fetch only proceeds once in_flight == 5.
+        release_fetch.set()
+        results = await asyncio.gather(*tasks)
 
     assert call_count == 1
     for r in results:


### PR DESCRIPTION
> **TL;DR.** Adds `schedule_workout` / `schedule_strength_workout` for the common case (schedule a workout on a date, no library entry) and renames the existing library-persisting tools with a `_template` suffix so the calling AI can tell the two paths apart without reading docstrings.

## Motivation

The current MCP forces every scheduled workout to round-trip through the user's Coros workout library. `create_strength_workout` POSTs to `/training/program/add` (persisting a template), then `schedule_workout` re-POSTs the template to `/training/schedule/update` to put it on the calendar. **Every one-off workout leaves library residue the user has to delete by hand.** The iOS app does NOT behave this way — it can post inline program data straight to `/training/schedule/update`, leaving the library untouched.

For 95% of MCP usage the user just wants "schedule this workout for Tuesday." Forcing them through the library is wrong. This PR makes inline scheduling the default and keeps the library path available, clearly marked, for users who actually want a reusable template.

## The naming choice (and why it minimizes future regret)

| Family | Pattern | Examples |
|---|---|---|
| **Common case (inline)** | short, unmodified verb | `schedule_workout`, `schedule_strength_workout` |
| **Library / template path** | verbose `_template` suffix | `save_workout_template`, `save_strength_workout_template`, `schedule_workout_template`, `list_workout_templates`, `delete_workout_template` |

**Why asymmetric, not symmetric:**

The MCP's primary consumer is an LLM scanning the tool list. Symmetric naming (`schedule_workout_inline` + `schedule_workout_template`) forces the LLM to read every docstring to disambiguate. Asymmetric naming biases tool selection *visually* — short name = common case, verbose name = exception. This is the same principle that makes `print()` a builtin and `sys.stdout.write()` a method: the common path gets the cheap identifier.

**Alternatives considered and rejected:**

- *Aliases for backwards compatibility.* MCP clients are stateless — they re-list tools on every connection. No long-lived caller pins an MCP tool name. Aliases would permanently bloat the tool list, defeating the AI-selection benefit above.
- *Keep `schedule_workout` for the library path and add `schedule_workout_inline` for inline.* Makes the library path the short name — the opposite of where we want bias.
- *Add a `mode: "inline" | "template"` parameter on a single tool.* MCP tool schemas flatten poorly under enum parameters; LLMs handle separate tools better than runtime branches.

The `schedule_workout` name is reused with a new signature. **This is a hard break, not a soft rename** — listed below in full so reviewers can see exactly what moves.

## Changes

| Old | New | Reason |
|---|---|---|
| `create_workout(name, steps, ...)` | `save_workout_template(name, steps, ...)` | "create" was ambiguous about whether it scheduled or persisted |
| `create_strength_workout(name, exercises, ...)` | `save_strength_workout_template(name, exercises, ...)` | same |
| `schedule_workout(workout_id, happen_day, ...)` | `schedule_workout_template(workout_id, happen_day, ...)` | name freed for the new inline tool below |
| `list_workouts()` | `list_workout_templates()` | the endpoint returns templates, not scheduled instances |
| `delete_workout(workout_id)` | `delete_workout_template(workout_id)` | same |
| _net new_ | `schedule_workout(name, steps, happen_day, ...)` | inline cycling/intervals one-off |
| _net new_ | `schedule_strength_workout(name, exercises, happen_day, ...)` | inline strength one-off |

Plus the internal helper `coros_api.fetch_workouts` → `fetch_workout_templates` for terminology consistency.

## What the inline path actually does

The new `schedule_workout` / `schedule_strength_workout` tools:

1. Build the program payload in memory (shared `_build_*_program_payload` helpers — same code path as the library-save tools, just no `/training/program/add` round-trip).
2. POST directly to `/training/schedule/update` with the program data embedded inline.
3. Follow up with a `_fetch_schedule_data` GET to surface the server-assigned identifiers (`plan_id`, `id_in_plan`, `plan_program_id`, `entity_id`) that `remove_scheduled_workout` needs.

The return shape is identical across both schedule paths (template and inline), so the LLM can pipe `response` straight into `remove_scheduled_workout` without a `list_planned_activities` lookup.

## Refactor (no behavior change)

- Extracted **sync** `_build_strength_program_payload(name, exercises, by_id, sets)` and `_build_workout_program_payload(name, steps, sport_type, intensity_type)` — pure functions, easily unit-testable. All four save/schedule paths share one builder per sport family.
- Extracted `_post_schedule_inline(auth, program, happen_day, sort_no)` — single `httpx.AsyncClient` wraps the maxIdInPlan probe, the schedule POST, and the enrichment GET. No mutation of caller's `program` dict.
- Extracted `_fetch_schedule_data(client, auth, start, end)` — three call sites (`fetch_schedule`, the probe, the enrichment) share one GET implementation so the reverse-engineered endpoint shape stays in lockstep.
- Strength-exercise catalog is now memoized at module scope with a 1-hour TTL (`asyncio.Lock` for first-load coalescing; doesn't cache `httpx.HTTPError` so transient failures retry). Was refetching all 382 exercises per strength operation.
- `_fetch_raw_workout` and the schedule-query GET now call `_check_response`, so a token-expiry / API error surfaces instead of masquerading as "workout not found" or silently falling through to `id_in_plan=1`.
- `_load_strength_catalog` narrowed its exception swallow to `httpx.HTTPError` so auth and API-level errors propagate.

## Tests

`tests/test_workout_payloads.py` — 30 unit tests, pure JSON-shape assertions and the async cache:

- Encoding rules: bodyweight (`intensityValue=""` + `intensityCustom=1`), kg / lbs (`intensityDisplayUnit "6"/"7"`), "Skip rests" (`restType=3`), defensive `status:1` per exercise, `sportType=4` consistency, catalog metadata enrichment + empty-list fallback on catalog miss, per-exercise vs circuit-sets duration math.
- Cycling builder: repeat groups, group↔sub-step linking, `power_low_w`/`power_high_w` legacy aliases, sport/intensity-type propagation.
- TTL cache: first-call fetches, second-call cached, refetch after TTL, HTTPError returns `{}` without poisoning the cache, 5 concurrent calls coalesce to 1 fetch (deterministic via `asyncio.Event`).

## Verified end-to-end on phone (2026-05-21)

- ✅ `schedule_strength_workout` → calendar entry with full schema parity (`sportType=4`, `restType=3`, T-codes, `target_value`, etc.). `list_workout_templates` confirms **no new library entry** — the load-bearing premise of the refactor.
- ✅ The returned `response` dict — `{plan_id, id_in_plan, plan_program_id, entity_id}` — piped directly into `remove_scheduled_workout` deletes the entry without a `list_planned_activities` round-trip.
- ✅ Same flow via `schedule_workout_template` (template path) — identical enriched return shape.
- ✅ `save_strength_workout_template` + `schedule_workout_template` creates one library entry + one referencing calendar entry, as designed.

## CI

74/74 pytest pass · `ruff check` clean · `mypy` clean.

## Documentation

README rewritten end-to-end: the tool table at the top leads with the inline tools (common case), per-tool sections grouped by family (templates next to each other, calendar tools next to each other), and the cross-references (anchor links between sections) all resolve.

## Out of scope / follow-ups

- Migrating existing library residue from prior MCP-created workouts — one-off cleanup the user can do via `delete_workout_template`.
- A `mode: "inline" | "template"` parameter that merges the seven tools into fewer — rejected above; LLMs handle separate tools better than runtime branches.
- Region-scoped catalog cache — catalog IDs are global, MCP is single-user; not needed unless we get bug reports.
