### PR TITLE
Support running workouts in schedule_workout / save_workout_template

### DIFF
--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -620,9 +620,9 @@ async def fetch_activity_detail(auth: StoredAuth, activity_id: str, sport_type: 
 # IntensityType values: 1=weight, 2=HR, 3=pace, 4=speed, 5=none, 6=power, 7=cadence
 
 WORKOUT_SPORT_NAMES: dict[int, str] = {
+    1: "Running",
     2: "Indoor Cycling",
     4: "Strength",
-    100: "Running",
     200: "Road Bike",
     201: "Indoor Cycling (alt)",
 }
@@ -727,10 +727,14 @@ def _build_workout_program_payload(
     sport_type: int = 2,
     intensity_type: int = 6,
 ) -> dict:
-    """Sync builder for the cycling/intervals program dict.
+    """Sync builder for the cycling/intervals/running program dict.
 
     steps: list of dicts — either plain steps or repeat groups (see
     save_workout_template docstring).
+
+    sport_type=100 builds a running program (mapped to the workout-side
+    sport ID and given the metadata block COROS requires for runs).
+    Cycling (the default) is unchanged.
     """
     if not steps:
         raise ValueError("workout requires at least one step")
@@ -738,6 +742,12 @@ def _build_workout_program_payload(
     top_index = 0  # counts top-level positions for sortNo
     total_seconds = 0
     ex_id = 0  # sequential exercise IDs (API uses these to link groups)
+
+    # Workout API uses sportType=1 for Running; activity API uses
+    # sportType=100. Accept the activity-side ID (matches list_activities)
+    # and map to the workout-side ID for the payload.
+    is_running = sport_type == 100
+    wire_sport_type = 1 if is_running else sport_type
 
     for step in steps:
         if "repeat" in step:
@@ -757,7 +767,7 @@ def _build_workout_program_payload(
                 "id": group_id,
                 "name": "Group",
                 "exerciseType": 0,
-                "sportType": sport_type,
+                "sportType": wire_sport_type,
                 "intensityType": 0,
                 "intensityValue": 0,
                 "targetType": 2,
@@ -778,7 +788,7 @@ def _build_workout_program_payload(
                     "id": ex_id,
                     "name": sub["name"],
                     "exerciseType": 2,
-                    "sportType": sport_type,
+                    "sportType": wire_sport_type,
                     "intensityType": intensity_type,
                     "intensityValue": sub.get("intensity_low", sub.get("power_low_w", 0)),
                     "intensityValueExtend": sub.get("intensity_high", sub.get("power_high_w", 0)),
@@ -802,7 +812,7 @@ def _build_workout_program_payload(
                 "id": ex_id,
                 "name": step["name"],
                 "exerciseType": 2,
-                "sportType": sport_type,
+                "sportType": wire_sport_type,
                 "intensityType": intensity_type,
                 "intensityValue": step.get("intensity_low", step.get("power_low_w", 0)),
                 "intensityValueExtend": step.get("intensity_high", step.get("power_high_w", 0)),
@@ -817,13 +827,67 @@ def _build_workout_program_payload(
                 "originId": "0",
             })
 
-    return {
+    payload = {
         "name": name,
-        "sportType": sport_type,
+        "sportType": wire_sport_type,
         "estimatedTime": total_seconds,
         "access": 1,
         "exercises": exercises,
     }
+
+    # Running programs need the same metadata block strength programs
+    # carry. Without it the COROS app fails to parse the entry or renders
+    # it as strength on the watch.
+    if is_running:
+        # Per-step exerciseType: 1=warmup, 2=main, 3=cooldown.
+        # hrType=2 marks HR-based targets.
+        plain_exercises = [e for e in exercises if not e.get("isGroup")]
+        last_idx = len(plain_exercises) - 1
+        for i, ex in enumerate(plain_exercises):
+            if i == 0 and last_idx > 0:
+                ex["exerciseType"] = 1   # warmup
+            elif i == last_idx and last_idx > 0:
+                ex["exerciseType"] = 3   # cooldown
+            else:
+                ex["exerciseType"] = 2   # main / single-step
+            ex.setdefault("exerciseKind", 0)
+            ex.setdefault("gradeSystem", 0)
+            ex["hrType"] = 2 if intensity_type == 2 else 0
+            ex.setdefault("intensityMultiplier", 0)
+            ex.setdefault("intensityPercent", 0)
+            ex.setdefault("intensityPercentExtend", 0)
+            ex.setdefault("onsightGradeOffset", 0)
+            ex.setdefault("overview", "")
+            ex.setdefault("packageTime", 0)
+            ex.setdefault("sourceId", "0")
+            ex.setdefault("subType", 0)
+            ex.setdefault("targetDisplayUnit", 0)
+        payload.update({
+            "duration": total_seconds,
+            "exerciseNum": len(exercises),
+            "gradeSystemVersion": 0,
+            "hybridTotalSets": 0,
+            "overview": "",
+            "poolLength": 0,
+            "poolLengthId": 0,
+            "poolLengthUnit": 0,
+            "referExercise": {
+                "gradeSystem": 0,
+                "hrType": 3 if intensity_type == 2 else 0,
+                "intensityType": 0,
+                "valueType": 1,
+            },
+            "sourceUrl": "",
+            # subType=65535 marks a structured workout (shared with strength).
+            "subType": 65535,
+            "totalSets": len(exercises),
+            "trainingLoad": 0,
+            "type": 0,
+            "videoCoverUrl": "",
+            "videoUrl": "",
+        })
+
+    return payload
 
 
 async def save_workout_template(

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -623,6 +623,11 @@ async def fetch_activity_detail(auth: StoredAuth, activity_id: str, sport_type: 
 # 100 (and 102 Trail, 103 Track). _build_workout_program_payload maps the
 # activity-side run IDs → 1 on the way out. The old 100: "Running" entry here
 # never round-tripped, because the API only ever speaks sportType=1 for runs.
+# Keyed by WORKOUT-namespace (wire) sport IDs — the sportType the workout API
+# stores and returns, not the activity-namespace IDs callers pass in. All run
+# flavors (activity 100/102/103) are collapsed to wire 1 on write, so a run
+# fetched back always reads as wire 1 here. Only consult this with wire IDs;
+# map activity IDs through _RUNNING_ACTIVITY_SPORT_TYPES first.
 WORKOUT_SPORT_NAMES: dict[int, str] = {
     1: "Running",
     2: "Indoor Cycling",
@@ -647,6 +652,8 @@ def _parse_workout(item: dict) -> dict:
             "intensity_high": ex.get("intensityValueExtend"),
             "sets": ex.get("sets", 1),
         })
+    # sportType from the workout API is always a wire ID (runs come back as 1,
+    # never 100/102/103), so the wire-keyed lookup below is correct here.
     sport = item.get("sportType")
     return {
         "id": str(item.get("id", "")),
@@ -887,6 +894,12 @@ def _build_workout_program_payload(
         for ex in exercises:
             if ex.get("isGroup"):
                 continue
+            # Repeat sub-steps (groupId != "0") are always main work. Set it
+            # explicitly here so running classification owns it, rather than
+            # silently inheriting the exerciseType=2 the construction path
+            # happens to write — a cycling-path refactor must not break this.
+            if ex.get("groupId", "0") != "0":
+                ex["exerciseType"] = 2
             ex.setdefault("exerciseKind", 0)
             ex.setdefault("gradeSystem", 0)
             ex["hrType"] = 2 if intensity_type == 2 else 0
@@ -899,9 +912,14 @@ def _build_workout_program_payload(
             ex.setdefault("sourceId", "0")
             ex.setdefault("subType", 0)
             ex.setdefault("targetDisplayUnit", 0)
+        # exerciseNum / totalSets count real exercise steps only. A repeat
+        # group adds a structural container row (isGroup=True) to `exercises`
+        # that is glue, not a step — counting it inflates these by one per
+        # group. Flat workouts have no containers, so this matches len() there.
+        real_step_count = sum(1 for e in exercises if not e.get("isGroup"))
         payload.update({
             "duration": total_seconds,
-            "exerciseNum": len(exercises),
+            "exerciseNum": real_step_count,
             "gradeSystemVersion": 0,
             "hybridTotalSets": 0,
             "overview": "",
@@ -917,7 +935,7 @@ def _build_workout_program_payload(
             "sourceUrl": "",
             # subType=65535 marks a structured workout (shared with strength).
             "subType": 65535,
-            "totalSets": len(exercises),
+            "totalSets": real_step_count,
             "trainingLoad": 0,
             "type": 0,
             "videoCoverUrl": "",

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -752,7 +752,7 @@ def _build_workout_program_payload(
     name: str,
     steps: list[dict],
     sport_type: int = 2,
-    intensity_type: int = 6,
+    intensity_type: int | None = None,
 ) -> dict:
     """Sync builder for the cycling/intervals/running program dict.
 
@@ -771,6 +771,10 @@ def _build_workout_program_payload(
     Passing the wire ID 1 directly is rejected — callers must use the
     activity-side run IDs so the running metadata block is always applied.
     Cycling (the default) is unchanged.
+
+    intensity_type=None resolves per sport: runs default to HR (2), the
+    natural running target; cycling/everything else defaults to power (6).
+    Pass an explicit value to override.
     """
     if not steps:
         raise ValueError("workout requires at least one step")
@@ -797,6 +801,11 @@ def _build_workout_program_payload(
         )
     is_running = sport_type in _RUNNING_ACTIVITY_SPORT_TYPES
     wire_sport_type = 1 if is_running else sport_type
+
+    # Resolve the per-sport default intensity: runs default to HR (2), the
+    # natural running target; cycling keeps power (6). An explicit value wins.
+    if intensity_type is None:
+        intensity_type = 2 if is_running else 6
 
     for step in steps:
         if "repeat" in step:
@@ -888,23 +897,24 @@ def _build_workout_program_payload(
     # carry. Without it the COROS app fails to parse the entry or renders
     # it as strength on the watch.
     if is_running:
-        # exerciseType markers (1=warmup, 3=cooldown) apply ONLY to top-level
-        # plain steps. A repeat group's sub-steps (groupId != "0") are always
-        # main work, and the group container (isGroup) is structural — neither
-        # is ever warmup/cooldown. Picking by position over *all* non-group
-        # rows would mislabel the first/last sub-step of an interval block.
+        # exerciseType markers (1=warmup, 3=cooldown) attach to the FIRST and
+        # LAST top-level steps, and only when those steps are plain. A repeat
+        # group is structural (never warmup/cooldown) and its sub-steps are
+        # always main work. Gating on the first/last top-level *items* — not on
+        # a count of plain steps — keeps the markers correct for shapes that mix
+        # a single plain step with a group: "[warmup, intervals]" still tags the
+        # warmup, "[intervals, cooldown]" still tags the cooldown. Everything
+        # else (interior plain steps, single-step workouts) stays main (the
+        # exerciseType=2 written at construction).
         top_level_plain = [
             e for e in exercises
             if not e.get("isGroup") and e.get("groupId", "0") == "0"
         ]
-        last_idx = len(top_level_plain) - 1
-        for i, ex in enumerate(top_level_plain):
-            if last_idx > 0 and i == 0:
-                ex["exerciseType"] = 1   # warmup
-            elif last_idx > 0 and i == last_idx:
-                ex["exerciseType"] = 3   # cooldown
-            else:
-                ex["exerciseType"] = 2   # main / single-step
+        if len(steps) > 1 and top_level_plain:
+            if "repeat" not in steps[0]:
+                top_level_plain[0]["exerciseType"] = 1   # warmup
+            if "repeat" not in steps[-1]:
+                top_level_plain[-1]["exerciseType"] = 3  # cooldown
         # Per-step run metadata applies to every non-group step — top-level
         # plain steps AND repeat sub-steps — so interval blocks render too.
         # The group container carries none. hrType=2 marks HR-based targets.
@@ -967,7 +977,7 @@ async def save_workout_template(
     name: str,
     steps: list[dict],
     sport_type: int = 2,
-    intensity_type: int = 6,
+    intensity_type: int | None = None,
 ) -> str:
     """
     Save a reusable cycling/intervals workout template to the Coros library.
@@ -1606,7 +1616,7 @@ async def schedule_workout(
     steps: list[dict],
     happen_day: str,
     sport_type: int = 2,
-    intensity_type: int = 6,
+    intensity_type: int | None = None,
     sort_no: int = 1,
 ) -> dict:
     """

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -641,6 +641,17 @@ WORKOUT_SPORT_NAMES: dict[int, str] = {
 # single Running wire ID (sportType=1) and carry the same metadata block.
 _RUNNING_ACTIVITY_SPORT_TYPES = frozenset({100, 102, 103})
 
+# Cycling sport IDs that pass through to the wire unchanged (no namespace
+# remap, no running metadata block): 2 Indoor Cycling, 200 Road Bike,
+# 201 Indoor Cycling (alt).
+_CYCLING_SPORT_TYPES = frozenset({2, 200, 201})
+
+# Every sport_type _build_workout_program_payload accepts. Anything else is
+# rejected rather than emitted as-is: an unknown ID would otherwise produce a
+# cycling-shaped payload with a bogus wire sportType that fails silently on
+# the COROS side. (Strength uses a separate builder and is not listed here.)
+_KNOWN_SPORT_TYPES = _RUNNING_ACTIVITY_SPORT_TYPES | _CYCLING_SPORT_TYPES
+
 
 def _parse_workout(item: dict) -> dict:
     exercises = []
@@ -777,6 +788,12 @@ def _build_workout_program_payload(
         raise ValueError(
             "Pass sport_type=100 for running (activity-namespace ID); 1 is the "
             "internal workout-API ID and must not be passed directly."
+        )
+    if sport_type not in _KNOWN_SPORT_TYPES:
+        raise ValueError(
+            f"Unknown sport_type={sport_type}. Supported: "
+            "100/102/103 (Running/Trail/Track), 2 (Indoor Cycling), "
+            "200 (Road Bike), 201 (Indoor Cycling alt)."
         )
     is_running = sport_type in _RUNNING_ACTIVITY_SPORT_TYPES
     wire_sport_type = 1 if is_running else sport_type

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -619,6 +619,10 @@ async def fetch_activity_detail(auth: StoredAuth, activity_id: str, sport_type: 
 # targetType=2 = time-based (seconds); exerciseType=2 = cycling block
 # IntensityType values: 1=weight, 2=HR, 3=pace, 4=speed, 5=none, 6=power, 7=cadence
 
+# Note: the workout API uses sportType=1 for Running; the activity API uses
+# 100 (and 102 Trail, 103 Track). _build_workout_program_payload maps the
+# activity-side run IDs → 1 on the way out. The old 100: "Running" entry here
+# never round-tripped, because the API only ever speaks sportType=1 for runs.
 WORKOUT_SPORT_NAMES: dict[int, str] = {
     1: "Running",
     2: "Indoor Cycling",
@@ -626,6 +630,11 @@ WORKOUT_SPORT_NAMES: dict[int, str] = {
     200: "Road Bike",
     201: "Indoor Cycling (alt)",
 }
+
+# Activity-namespace sport IDs that are run flavors. The workout API has no
+# separate trail/track/treadmill workout type — they all collapse to the
+# single Running wire ID (sportType=1) and carry the same metadata block.
+_RUNNING_ACTIVITY_SPORT_TYPES = frozenset({100, 102, 103})
 
 
 def _parse_workout(item: dict) -> dict:
@@ -732,8 +741,17 @@ def _build_workout_program_payload(
     steps: list of dicts — either plain steps or repeat groups (see
     save_workout_template docstring).
 
-    sport_type=100 builds a running program (mapped to the workout-side
-    sport ID and given the metadata block COROS requires for runs).
+    sport_type uses the activity namespace (the IDs list_activities
+    returns), not the workout-API wire IDs:
+
+      - 2   = Indoor Cycling (default)
+      - 200 = Road Bike, 201 = Indoor Cycling (alt)
+      - 100 = Running, 102 = Trail Running, 103 = Track Running
+        (all mapped to the workout-side wire ID sportType=1 and given the
+        metadata block COROS requires for runs)
+
+    Passing the wire ID 1 directly is rejected — callers must use the
+    activity-side run IDs so the running metadata block is always applied.
     Cycling (the default) is unchanged.
     """
     if not steps:
@@ -743,10 +761,17 @@ def _build_workout_program_payload(
     total_seconds = 0
     ex_id = 0  # sequential exercise IDs (API uses these to link groups)
 
-    # Workout API uses sportType=1 for Running; activity API uses
-    # sportType=100. Accept the activity-side ID (matches list_activities)
-    # and map to the workout-side ID for the payload.
-    is_running = sport_type == 100
+    # Workout API uses a single Running wire ID (sportType=1); the activity
+    # API splits runs into 100 (Running), 102 (Trail), 103 (Track). Accept
+    # the activity-side IDs (what list_activities returns) and map them onto
+    # the wire ID. Reject the wire ID itself so a caller can't slip past the
+    # running metadata block and reproduce the app-crash / strength-render bug.
+    if sport_type == 1:
+        raise ValueError(
+            "Pass sport_type=100 for running (activity-namespace ID); 1 is the "
+            "internal workout-API ID and must not be passed directly."
+        )
+    is_running = sport_type in _RUNNING_ACTIVITY_SPORT_TYPES
     wire_sport_type = 1 if is_running else sport_type
 
     for step in steps:
@@ -839,17 +864,29 @@ def _build_workout_program_payload(
     # carry. Without it the COROS app fails to parse the entry or renders
     # it as strength on the watch.
     if is_running:
-        # Per-step exerciseType: 1=warmup, 2=main, 3=cooldown.
-        # hrType=2 marks HR-based targets.
-        plain_exercises = [e for e in exercises if not e.get("isGroup")]
-        last_idx = len(plain_exercises) - 1
-        for i, ex in enumerate(plain_exercises):
-            if i == 0 and last_idx > 0:
+        # exerciseType markers (1=warmup, 3=cooldown) apply ONLY to top-level
+        # plain steps. A repeat group's sub-steps (groupId != "0") are always
+        # main work, and the group container (isGroup) is structural — neither
+        # is ever warmup/cooldown. Picking by position over *all* non-group
+        # rows would mislabel the first/last sub-step of an interval block.
+        top_level_plain = [
+            e for e in exercises
+            if not e.get("isGroup") and e.get("groupId", "0") == "0"
+        ]
+        last_idx = len(top_level_plain) - 1
+        for i, ex in enumerate(top_level_plain):
+            if last_idx > 0 and i == 0:
                 ex["exerciseType"] = 1   # warmup
-            elif i == last_idx and last_idx > 0:
+            elif last_idx > 0 and i == last_idx:
                 ex["exerciseType"] = 3   # cooldown
             else:
                 ex["exerciseType"] = 2   # main / single-step
+        # Per-step run metadata applies to every non-group step — top-level
+        # plain steps AND repeat sub-steps — so interval blocks render too.
+        # The group container carries none. hrType=2 marks HR-based targets.
+        for ex in exercises:
+            if ex.get("isGroup"):
+                continue
             ex.setdefault("exerciseKind", 0)
             ex.setdefault("gradeSystem", 0)
             ex["hrType"] = 2 if intensity_type == 2 else 0

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -657,7 +657,7 @@ async def save_workout_template(
     name: str,
     steps: list[dict],
     sport_type: int = 2,
-    intensity_type: int = 6,
+    intensity_type: int | None = None,
 ) -> dict:
     """
     Save a REUSABLE cycling/intervals/running workout TEMPLATE to the Coros library.
@@ -716,10 +716,10 @@ async def save_workout_template(
         Running IDs are mapped internally to the workout-API wire ID
         (sportType=1) and given the metadata block COROS requires for runs.
         Do NOT pass 1 directly — it's the internal wire ID and is rejected.
-    intensity_type : int
-        Intensity type ID. Default 6 = power in watts.
+    intensity_type : int, optional
+        Intensity type ID. Defaults per sport when omitted: runs → 2 (HR),
+        cycling → 6 (power in watts).
         Other IntensityType values: 1=weight, 2=HR, 3=pace, 4=speed, 5=none, 6=power, 7=cadence
-        For runs, 2 (HR) is typical.
 
     Returns
     -------
@@ -945,7 +945,7 @@ async def schedule_workout(
     steps: list[dict],
     happen_day: str,
     sport_type: int = 2,
-    intensity_type: int = 6,
+    intensity_type: int | None = None,
     sort_no: int = 1,
 ) -> dict:
     """
@@ -977,8 +977,9 @@ async def schedule_workout(
         100 = Running, 102 = Trail Running, 103 = Track Running — these map
         internally to the workout wire ID (sportType=1) and get the running
         metadata block. Don't pass 1 directly (it's the wire ID and is rejected).
-    intensity_type : int
-        Intensity type ID (default 6 = power in watts; use 2 = HR for runs).
+    intensity_type : int, optional
+        Intensity type ID. Defaults per sport when omitted: runs → 2 (HR),
+        cycling → 6 (power in watts).
     sort_no : int
         Order within the day (default 1).
 

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -141,13 +141,13 @@ async def get_help() -> dict:
             {"name": "list_workout_templates", "description": "List reusable workout templates saved in the Coros library"},  # noqa: E501
             {"name": "list_training_plans", "description": "List training plans saved in the Coros Training Hub"},  # noqa: E501
             {"name": "list_training_plans_raw", "description": "List raw training plans including entities and programs"},  # noqa: E501
-            {"name": "save_workout_template", "description": "Save a reusable cycling/intervals workout template to the library"},  # noqa: E501
+            {"name": "save_workout_template", "description": "Save a reusable cycling/intervals/running workout template to the library"},  # noqa: E501
             {"name": "save_strength_workout_template", "description": "Save a reusable strength workout template to the library"},  # noqa: E501
             {"name": "delete_workout_template", "description": "Delete a saved workout template by workout_id"},
             {"name": "list_planned_activities", "description": "List workouts scheduled on the training calendar"},
             {"name": "list_planned_activities_raw", "description": "List raw scheduled workouts for calendar update workflows"},  # noqa: E501
             {"name": "calculate_workout_program", "description": "Recalculate edited workout program metrics before updating"},  # noqa: E501
-            {"name": "schedule_workout", "description": "Schedule a one-off cycling/intervals workout for a date (no library entry)"},  # noqa: E501
+            {"name": "schedule_workout", "description": "Schedule a one-off cycling/intervals/running workout for a date (no library entry)"},  # noqa: E501
             {"name": "add_planned_workout", "description": "Add an inline planned workout to the training calendar from raw objects"},  # noqa: E501
             {"name": "update_scheduled_workout", "description": "Update an existing scheduled workout on the calendar"},  # noqa: E501
             {"name": "schedule_strength_workout", "description": "Schedule a one-off strength workout for a date (no library entry)"},  # noqa: E501
@@ -660,7 +660,7 @@ async def save_workout_template(
     intensity_type: int = 6,
 ) -> dict:
     """
-    Save a REUSABLE cycling/intervals workout TEMPLATE to the Coros library.
+    Save a REUSABLE cycling/intervals/running workout TEMPLATE to the Coros library.
 
     ⚠️ This persists to the library indefinitely. Use ONLY when the user
     explicitly asks to "save as a template", "create a workout in my
@@ -708,11 +708,18 @@ async def save_workout_template(
         ]
 
     sport_type : int
-        Sport type ID. Default 2 = Indoor Cycling (Rollen).
-        Use 200 for Road Bike (outdoor), 201 for Indoor Cycling (alt).
+        Sport type ID, in the ACTIVITY namespace (the same IDs list_activities
+        returns). Default 2 = Indoor Cycling (Rollen).
+        - Cycling: 2 = Indoor Cycling (Rollen), 200 = Road Bike (outdoor),
+          201 = Indoor Cycling (alt)
+        - Running: 100 = Running, 102 = Trail Running, 103 = Track Running
+        Running IDs are mapped internally to the workout-API wire ID
+        (sportType=1) and given the metadata block COROS requires for runs.
+        Do NOT pass 1 directly — it's the internal wire ID and is rejected.
     intensity_type : int
         Intensity type ID. Default 6 = power in watts.
         Other IntensityType values: 1=weight, 2=HR, 3=pace, 4=speed, 5=none, 6=power, 7=cadence
+        For runs, 2 (HR) is typical.
 
     Returns
     -------
@@ -942,7 +949,7 @@ async def schedule_workout(
     sort_no: int = 1,
 ) -> dict:
     """
-    Schedule a ONE-OFF cycling/intervals workout for a specific date.
+    Schedule a ONE-OFF cycling/intervals/running workout for a specific date.
 
     This is the COMMON case. Use this whenever the user wants a workout
     on a specific date and doesn't explicitly ask for a reusable template.
@@ -965,9 +972,13 @@ async def schedule_workout(
     happen_day : str
         Date in YYYYMMDD format.
     sport_type : int
-        Sport type ID (default 2 = Indoor Cycling).
+        Sport type ID, in the ACTIVITY namespace (as list_activities returns).
+        Default 2 = Indoor Cycling. 200 = Road Bike, 201 = Indoor Cycling (alt).
+        100 = Running, 102 = Trail Running, 103 = Track Running — these map
+        internally to the workout wire ID (sportType=1) and get the running
+        metadata block. Don't pass 1 directly (it's the wire ID and is rejected).
     intensity_type : int
-        Intensity type ID (default 6 = power in watts).
+        Intensity type ID (default 6 = power in watts; use 2 = HR for runs).
     sort_no : int
         Order within the day (default 1).
 

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -332,6 +332,106 @@ def test_cycling_sport_and_intensity_types_propagate():
 
 
 # ---------------------------------------------------------------------------
+# Running builder (sport_type=100 → workout namespace sportType=1)
+# ---------------------------------------------------------------------------
+
+def test_running_maps_activity_id_to_workout_id():
+    """sport_type=100 (activity namespace) is rewritten to sportType=1
+    (workout namespace) at program and exercise level."""
+    payload = _build_workout_program_payload(
+        name="Easy Z2 run",
+        steps=[
+            {"name": "Warm-up", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+            {"name": "Z2",      "duration_minutes": 20, "intensity_low": 125, "intensity_high": 145},
+            {"name": "Cool",    "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    assert payload["sportType"] == 1
+    for ex in payload["exercises"]:
+        assert ex["sportType"] == 1
+
+
+def test_running_emits_structured_workout_metadata():
+    """Running programs carry the structured-workout metadata block
+    (referExercise, subType=65535, type=0, etc.)."""
+    payload = _build_workout_program_payload(
+        name="r",
+        steps=[
+            {"name": "W", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+            {"name": "M", "duration_minutes": 20, "intensity_low": 125, "intensity_high": 145},
+            {"name": "C", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    assert payload["subType"] == 65535
+    assert payload["type"] == 0
+    assert payload["referExercise"] == {
+        "gradeSystem": 0, "hrType": 3, "intensityType": 0, "valueType": 1,
+    }
+    assert payload["totalSets"] == 3
+    assert payload["duration"] == (5 + 20 + 5) * 60
+
+
+def test_running_exercise_type_varies_by_position():
+    """Per-step exerciseType: 1=warmup, 2=main, 3=cooldown."""
+    payload = _build_workout_program_payload(
+        name="r",
+        steps=[
+            {"name": "W", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+            {"name": "M", "duration_minutes": 20, "intensity_low": 125, "intensity_high": 145},
+            {"name": "C", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    assert [ex["exerciseType"] for ex in payload["exercises"]] == [1, 2, 3]
+
+
+def test_running_single_step_uses_main_exercise_type():
+    """A single-step run is the main block (exerciseType=2), not warmup/cooldown."""
+    payload = _build_workout_program_payload(
+        name="open",
+        steps=[{"name": "Run", "duration_minutes": 30, "intensity_low": 0, "intensity_high": 0}],
+        sport_type=100,
+        intensity_type=5,
+    )
+    assert payload["exercises"][0]["exerciseType"] == 2
+    assert payload["exercises"][0]["hrType"] == 0
+    assert payload["referExercise"]["hrType"] == 0
+
+
+def test_running_hr_intensity_marks_hr_type():
+    """intensity_type=2 (HR) sets hrType=2 per step and referExercise.hrType=3."""
+    payload = _build_workout_program_payload(
+        name="r",
+        steps=[
+            {"name": "W", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+            {"name": "M", "duration_minutes": 20, "intensity_low": 125, "intensity_high": 145},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    assert all(ex["hrType"] == 2 for ex in payload["exercises"])
+    assert payload["referExercise"]["hrType"] == 3
+
+
+def test_running_does_not_affect_cycling():
+    """Cycling programs keep their existing sparse shape (no metadata block)."""
+    payload = _build_workout_program_payload(
+        name="c",
+        steps=[{"name": "ride", "duration_minutes": 30, "intensity_low": 200, "intensity_high": 250}],
+        sport_type=2,
+    )
+    assert payload["sportType"] == 2
+    assert "subType" not in payload
+    assert "referExercise" not in payload
+    assert "type" not in payload
+
+
+# ---------------------------------------------------------------------------
 # Strength catalog cache (_load_strength_catalog)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -480,6 +480,31 @@ def test_running_repeat_group_substeps_are_main():
     assert all(ex["hrType"] == 2 for ex in sub_steps)
 
 
+def test_running_repeat_group_counts_real_steps_only():
+    """exerciseNum / totalSets count real steps, not the structural group
+    container. [warmup, repeat(3× [hard, easy]), cooldown] has 4 real steps
+    (warmup, hard, easy, cooldown) even though `exercises` holds 5 rows."""
+    payload = _build_workout_program_payload(
+        name="intervals",
+        steps=[
+            {"name": "Warm", "duration_minutes": 10, "intensity_low": 120, "intensity_high": 140},
+            {"repeat": 3, "steps": [
+                {"name": "Hard", "duration_minutes": 3, "intensity_low": 165, "intensity_high": 175},
+                {"name": "Easy", "duration_minutes": 2, "intensity_low": 120, "intensity_high": 140},
+            ]},
+            {"name": "Cool", "duration_minutes": 10, "intensity_low": 120, "intensity_high": 140},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    # 5 rows in `exercises` (one is the isGroup container)...
+    assert len(payload["exercises"]) == 5
+    assert sum(e.get("isGroup", False) for e in payload["exercises"]) == 1
+    # ...but only 4 are real exercise steps.
+    assert payload["exerciseNum"] == 4
+    assert payload["totalSets"] == 4
+
+
 def test_running_repeat_group_only_all_main():
     """[repeat(3× [hard, easy])] with no surrounding plain steps: both
     sub-steps are main (2) — never warmup/cooldown."""

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -431,6 +431,105 @@ def test_running_does_not_affect_cycling():
     assert "type" not in payload
 
 
+def test_cycling_payload_top_level_keys_are_exact():
+    """Cycling payload must not leak the running metadata block — its
+    top-level key set is exactly the sparse five."""
+    payload = _build_workout_program_payload(
+        name="c",
+        steps=[
+            {"name": "warm", "duration_minutes": 10, "intensity_low": 150, "intensity_high": 175},
+            {"repeat": 3, "steps": [
+                {"name": "on",  "duration_minutes": 5, "intensity_low": 265, "intensity_high": 285},
+                {"name": "off", "duration_minutes": 3, "intensity_low": 150, "intensity_high": 175},
+            ]},
+            {"name": "cool", "duration_minutes": 10, "intensity_low": 100, "intensity_high": 165},
+        ],
+        sport_type=2,
+    )
+    assert set(payload.keys()) == {"name", "sportType", "estimatedTime", "access", "exercises"}
+
+
+def test_running_repeat_group_substeps_are_main():
+    """[warmup, repeat(3× [hard, easy]), cooldown]: only the top-level
+    warmup is exerciseType=1 and only the cooldown is 3; every sub-step
+    inside the group stays main (2), and the group container stays 0."""
+    payload = _build_workout_program_payload(
+        name="intervals",
+        steps=[
+            {"name": "Warm", "duration_minutes": 10, "intensity_low": 120, "intensity_high": 140},
+            {"repeat": 3, "steps": [
+                {"name": "Hard", "duration_minutes": 3, "intensity_low": 165, "intensity_high": 175},
+                {"name": "Easy", "duration_minutes": 2, "intensity_low": 120, "intensity_high": 140},
+            ]},
+            {"name": "Cool", "duration_minutes": 10, "intensity_low": 120, "intensity_high": 140},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    exercises = payload["exercises"]
+    # Order: warmup, group, hard, easy, cooldown
+    assert [ex["exerciseType"] for ex in exercises] == [1, 0, 2, 2, 3]
+    # Every repeat sub-step (groupId != "0", not the container) is main.
+    sub_steps = [e for e in exercises if not e.get("isGroup") and e.get("groupId") != "0"]
+    assert len(sub_steps) == 2
+    assert all(ex["exerciseType"] == 2 for ex in sub_steps)
+    # Exactly one warmup and one cooldown across the whole workout.
+    assert sum(ex["exerciseType"] == 1 for ex in exercises) == 1
+    assert sum(ex["exerciseType"] == 3 for ex in exercises) == 1
+    # Sub-steps still carry the per-step run metadata so they render.
+    assert all(ex["hrType"] == 2 for ex in sub_steps)
+
+
+def test_running_repeat_group_only_all_main():
+    """[repeat(3× [hard, easy])] with no surrounding plain steps: both
+    sub-steps are main (2) — never warmup/cooldown."""
+    payload = _build_workout_program_payload(
+        name="just intervals",
+        steps=[
+            {"repeat": 3, "steps": [
+                {"name": "Hard", "duration_minutes": 3, "intensity_low": 165, "intensity_high": 175},
+                {"name": "Easy", "duration_minutes": 2, "intensity_low": 120, "intensity_high": 140},
+            ]},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    exercises = payload["exercises"]
+    assert [ex["exerciseType"] for ex in exercises] == [0, 2, 2]
+    assert not any(ex["exerciseType"] in (1, 3) for ex in exercises)
+
+
+@pytest.mark.parametrize("sport_type", [102, 103])
+def test_trail_and_track_map_to_running(sport_type):
+    """Trail (102) and Track (103) Running are run flavors too — they map to
+    wire sportType=1 and get the same metadata block, not a bare payload."""
+    payload = _build_workout_program_payload(
+        name="r",
+        steps=[
+            {"name": "W", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+            {"name": "M", "duration_minutes": 20, "intensity_low": 125, "intensity_high": 145},
+            {"name": "C", "duration_minutes": 5,  "intensity_low": 100, "intensity_high": 130},
+        ],
+        sport_type=sport_type,
+        intensity_type=2,
+    )
+    assert payload["sportType"] == 1
+    assert all(ex["sportType"] == 1 for ex in payload["exercises"])
+    assert payload["subType"] == 65535
+    assert "referExercise" in payload
+
+
+def test_wire_sport_type_id_is_rejected():
+    """Passing the workout-API wire ID (1) directly is rejected — callers
+    must use the activity-namespace ID (100) so the metadata block applies."""
+    with pytest.raises(ValueError, match="sport_type=100"):
+        _build_workout_program_payload(
+            name="r",
+            steps=[{"name": "Run", "duration_minutes": 30, "intensity_low": 0, "intensity_high": 0}],
+            sport_type=1,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Strength catalog cache (_load_strength_catalog)
 # ---------------------------------------------------------------------------

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -555,6 +555,59 @@ def test_wire_sport_type_id_is_rejected():
         )
 
 
+def test_running_two_step_exercise_types():
+    """Two plain steps: first=warmup(1), second=cooldown(3), no main block.
+    Pins current behaviour — the COROS app accepts this shape on-device."""
+    payload = _build_workout_program_payload(
+        name="r",
+        steps=[
+            {"name": "W", "duration_minutes": 5, "intensity_low": 100, "intensity_high": 130},
+            {"name": "C", "duration_minutes": 5, "intensity_low": 100, "intensity_high": 130},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    assert [ex["exerciseType"] for ex in payload["exercises"]] == [1, 3]
+
+
+@pytest.mark.parametrize("intensity_type", [3, 4, 5, 7])  # pace, speed, none, cadence
+def test_running_non_hr_intensity_emits_hr_type_zero(intensity_type):
+    """For any non-HR intensity (intensity_type != 2), hrType is 0 on every
+    step and referExercise.hrType is 0 — only HR targeting flips them on."""
+    payload = _build_workout_program_payload(
+        name="r",
+        steps=[{"name": "Run", "duration_minutes": 30, "intensity_low": 0, "intensity_high": 0}],
+        sport_type=100,
+        intensity_type=intensity_type,
+    )
+    assert all(ex["hrType"] == 0 for ex in payload["exercises"])
+    assert payload["referExercise"]["hrType"] == 0
+
+
+def test_road_bike_not_treated_as_running():
+    """sport_type=200 (Road Bike) takes the cycling path: wire sportType is
+    passed through unchanged and the running metadata block is absent."""
+    payload = _build_workout_program_payload(
+        name="c",
+        steps=[{"name": "ride", "duration_minutes": 60, "intensity_low": 200, "intensity_high": 250}],
+        sport_type=200,
+    )
+    assert payload["sportType"] == 200
+    assert "subType" not in payload
+    assert "referExercise" not in payload
+
+
+def test_unknown_sport_type_is_rejected():
+    """An unknown sport_type is rejected rather than emitted as a bogus wire
+    ID that would fail silently on the COROS side."""
+    with pytest.raises(ValueError, match="Unknown sport_type=50"):
+        _build_workout_program_payload(
+            name="x",
+            steps=[{"name": "step", "duration_minutes": 30, "intensity_low": 0, "intensity_high": 0}],
+            sport_type=50,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Strength catalog cache (_load_strength_catalog)
 # ---------------------------------------------------------------------------

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -608,6 +608,65 @@ def test_unknown_sport_type_is_rejected():
         )
 
 
+def test_running_warmup_before_group_is_tagged():
+    """[warmup, repeat(...)] (no trailing plain cooldown): the leading plain
+    step is still warmup (1), not main — the marker keys off the first
+    top-level item, not a count of plain steps. Sub-steps stay main (2)."""
+    payload = _build_workout_program_payload(
+        name="warm then intervals",
+        steps=[
+            {"name": "Warm", "duration_minutes": 10, "intensity_low": 120, "intensity_high": 140},
+            {"repeat": 3, "steps": [
+                {"name": "Hard", "duration_minutes": 3, "intensity_low": 165, "intensity_high": 175},
+                {"name": "Easy", "duration_minutes": 2, "intensity_low": 120, "intensity_high": 140},
+            ]},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    # Order: warmup, group, hard, easy
+    assert [ex["exerciseType"] for ex in payload["exercises"]] == [1, 0, 2, 2]
+
+
+def test_running_group_then_cooldown_is_tagged():
+    """[repeat(...), cooldown] (no leading plain warmup): the trailing plain
+    step is still cooldown (3), not main. Sub-steps stay main (2)."""
+    payload = _build_workout_program_payload(
+        name="intervals then cool",
+        steps=[
+            {"repeat": 3, "steps": [
+                {"name": "Hard", "duration_minutes": 3, "intensity_low": 165, "intensity_high": 175},
+                {"name": "Easy", "duration_minutes": 2, "intensity_low": 120, "intensity_high": 140},
+            ]},
+            {"name": "Cool", "duration_minutes": 10, "intensity_low": 120, "intensity_high": 140},
+        ],
+        sport_type=100,
+        intensity_type=2,
+    )
+    # Order: group, hard, easy, cooldown
+    assert [ex["exerciseType"] for ex in payload["exercises"]] == [0, 2, 2, 3]
+
+
+def test_intensity_type_defaults_per_sport():
+    """When intensity_type is omitted it resolves per sport: runs default to
+    HR (2), cycling to power (6). An explicit value still wins."""
+    run = _build_workout_program_payload(
+        name="r",
+        steps=[{"name": "Run", "duration_minutes": 30, "intensity_low": 120, "intensity_high": 150}],
+        sport_type=100,
+    )
+    assert run["exercises"][0]["intensityType"] == 2
+    assert run["exercises"][0]["hrType"] == 2
+    assert run["referExercise"]["hrType"] == 3
+
+    ride = _build_workout_program_payload(
+        name="c",
+        steps=[{"name": "Ride", "duration_minutes": 30, "intensity_low": 200, "intensity_high": 240}],
+        sport_type=2,
+    )
+    assert ride["exercises"][0]["intensityType"] == 6
+
+
 # ---------------------------------------------------------------------------
 # Strength catalog cache (_load_strength_catalog)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`schedule_workout` / `save_workout_template` previously only produced valid payloads for cycling/intervals. Passing a run (e.g. `sport_type=100`) produced an entry that crashed the COROS iPhone app on open, and once enough fields were stripped to stop the crash the watch rendered the entry as Strength (no running interface, no HR zones).

This PR makes the same builder produce a valid Running payload.

## What changed

`_build_workout_program_payload` in `coros_api.py`:

- **Sport-type namespace mapping.** The COROS activity API and workout API use different sport IDs (activity `100` = Running, workout `1` = Running). Callers naturally pass the activity-side ID (it's what `list_activities` returns). The builder now accepts `sport_type=100` and maps it to wire `sportType=1` at program and exercise level. Cycling IDs are passed through unchanged.
- **Structured-workout metadata block.** Run programs need the same metadata strength programs already carry — without it the COROS app fails to parse the entry. Added at program level: `subType=65535` (the structured-workout marker), `referExercise`, `type`, `overview`, `poolLength*`, `sourceUrl`, `videoCoverUrl/Url`, `gradeSystemVersion`, `hybridTotalSets`, `duration`, `exerciseNum`, `totalSets`, `trainingLoad`. Added per step: `exerciseKind`, `gradeSystem`, `hrType`, `intensityMultiplier`, `intensityPercent*`, `onsightGradeOffset`, `overview`, `packageTime`, `sourceId`, `subType`, `targetDisplayUnit`.
- **Per-step `exerciseType` by position:** `1`=warmup (first step), `3`=cooldown (last step), `2`=main (everything else, and single-step workouts).
- **HR targeting:** when `intensity_type=2` (HR), per-step `hrType=2` and program-level `referExercise.hrType=3`.
- **`WORKOUT_SPORT_NAMES` fix:** the previous entry mapped Running to `100`, but the workout API actually returns `sportType=1`, so it never round-tripped. Replaced with `1: \"Running\"`.

Cycling/intervals path is untouched.

## Tests

`tests/test_workout_payloads.py` — 6 new tests:

- Namespace mapping (`sport_type=100` → wire `1`).
- Program-level structured-workout metadata block present for runs.
- Per-step `exerciseType` varies by position (`[1, 2, 3]`).
- Single-step run uses `exerciseType=2`.
- HR intensity sets per-step `hrType=2` + `referExercise.hrType=3`.
- Cycling payloads unchanged.

Full suite (81 tests) passes.

## Manual verification

Pushed an HR-targeted multi-step run via the patched builder:

- Opens in the COROS iPhone app
- Syncs to the watch
- Renders as Running with the prescribed HR zones per step