### PR TITLE
fix: post-v0.3 review findings (lap dedup, env-token precedence, robustness)

### DIFF
--- a/coros_mcp/cache/sync.py
+++ b/coros_mcp/cache/sync.py
@@ -55,11 +55,12 @@ def _today() -> str:
 
 
 def _env_int(name: str, default: int) -> int:
-    """Read a non-negative int from the environment, falling back to `default`.
+    """Read an int from the environment, falling back to `default`.
 
-    A malformed value logs a warning and uses the default rather than raising —
-    this runs at import time, so an uncaught ValueError would crash the whole
-    MCP server with an opaque traceback instead of degrading gracefully.
+    A malformed (non-integer) value logs a warning and uses the default rather
+    than raising — this runs at import time, so an uncaught ValueError would
+    crash the whole MCP server with an opaque traceback instead of degrading
+    gracefully. The value itself is not range-checked.
     """
     raw = os.getenv(name)
     if raw is None:

--- a/coros_mcp/cache/sync.py
+++ b/coros_mcp/cache/sync.py
@@ -54,12 +54,29 @@ def _today() -> str:
     return datetime.now().strftime("%Y%m%d")
 
 
+def _env_int(name: str, default: int) -> int:
+    """Read a non-negative int from the environment, falling back to `default`.
+
+    A malformed value logs a warning and uses the default rather than raising —
+    this runs at import time, so an uncaught ValueError would crash the whole
+    MCP server with an opaque traceback instead of degrading gracefully.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r (not an integer); using default %d", name, raw, default)
+        return default
+
+
 # Data older than this many days is considered stable (immutable).
 # Recent data is always re-fetched to capture same-day activities and
 # delayed watch→phone syncs (HRV, sleep scores can arrive hours later).
 # Override with COROS_STABLE_DAYS env var (e.g. set to 0 to disable re-fetch,
 # or higher if your watch takes longer to sync to the phone).
-STABLE_AFTER_DAYS = int(os.getenv("COROS_STABLE_DAYS", "2"))
+STABLE_AFTER_DAYS = _env_int("COROS_STABLE_DAYS", 2)
 
 # Maximum range per API call. /analyse/dayDetail/query supports up to ~24
 # weeks; 12 weeks leaves comfortable headroom and matches sync_all's chunking.

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -310,26 +310,48 @@ def get_stored_auth() -> StoredAuth | None:
     token (for MCP server use cases where keyring is not accessible in the
     subprocess). Stored user_id, region, and mobile token/payload are kept
     so sleep data still works alongside an env-provided web token.
+
+    Precedence depends on whether refreshable credentials (COROS_EMAIL /
+    COROS_PASSWORD) are also configured:
+
+    - No credentials: the env token is externally managed and assumed always
+      valid, so it always wins.
+    - Credentials present: a *valid* stored token wins over the env token.
+      This lets a token minted by a prior auto-login (after the env token went
+      stale) take effect — otherwise every call would re-pay one failed
+      request plus a re-login because the stale env token was always preferred.
+      The env token is still used as a seed when no valid stored token exists.
     """
-    # Prefer explicit env var token when provided
     access_token = os.environ.get("COROS_ACCESS_TOKEN")
-    if access_token:
+    have_credentials = get_env_credentials() is not None
+
+    def _env_auth() -> StoredAuth:
         stored = _load_auth()
         region = os.environ.get("COROS_REGION") or (stored.region if stored else "eu")
         # Timestamp is set to now so the TTL check always passes — env-var
         # tokens are assumed to be externally managed and always valid.
         return StoredAuth(
-            access_token=access_token,
+            access_token=access_token,  # type: ignore[arg-type]  # guarded by callers
             user_id=stored.user_id if stored else "env",
             region=region,
             timestamp=int(time.time() * 1000),
             mobile_access_token=stored.mobile_access_token if stored else None,
             mobile_login_payload=stored.mobile_login_payload if stored else None,
         )
-    # Fall back to stored auth
+
+    # Externally-managed env token with nothing to self-refresh from → trust it.
+    if access_token and not have_credentials:
+        return _env_auth()
+
+    # Prefer a valid stored token (e.g. one minted by a prior auto-login).
     auth = _load_auth()
     if auth and _is_token_valid(auth):
         return auth
+
+    # Credentials present but no valid stored token yet: fall back to the env
+    # token as a seed if one was provided, otherwise signal "needs login".
+    if access_token:
+        return _env_auth()
     return None
 
 
@@ -1718,7 +1740,8 @@ async def add_planned_workout(
     if id_in_plan is None:
         raise ValueError("entity/program must include idInPlan for schedule add")
 
-    program.setdefault("idInPlan", id_in_plan)
+    # Copy rather than mutate the caller's program dict.
+    program = {**program, "idInPlan": program.get("idInPlan", id_in_plan)}
     payload = {
         "entities": [entity],
         "programs": [program],

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -324,9 +324,9 @@ def get_stored_auth() -> StoredAuth | None:
     """
     access_token = os.environ.get("COROS_ACCESS_TOKEN")
     have_credentials = get_env_credentials() is not None
+    stored = _load_auth()  # loaded once; reused by both the env and stored paths
 
     def _env_auth() -> StoredAuth:
-        stored = _load_auth()
         region = os.environ.get("COROS_REGION") or (stored.region if stored else "eu")
         # Timestamp is set to now so the TTL check always passes — env-var
         # tokens are assumed to be externally managed and always valid.
@@ -344,9 +344,8 @@ def get_stored_auth() -> StoredAuth | None:
         return _env_auth()
 
     # Prefer a valid stored token (e.g. one minted by a prior auto-login).
-    auth = _load_auth()
-    if auth and _is_token_valid(auth):
-        return auth
+    if stored and _is_token_valid(stored):
+        return stored
 
     # Credentials present but no valid stored token yet: fall back to the env
     # token as a seed if one was provided, otherwise signal "needs login".

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -442,6 +442,9 @@ async def list_activities(
     Returns
     -------
     dict with keys: activities (list), total_count, page
+    total_count is the number of activities in the local cache for the
+    requested range (the source of pagination here), which may differ from
+    the Coros server's own total until a sync has fully backfilled the range.
     Each activity contains: activity_id, name, sport_type, sport_name,
     start_time (local datetime string "YYYY-MM-DD HH:MM:SS", per COROS_TIMEZONE),
     end_time (same format), duration_seconds, distance_meters, avg_hr, max_hr,
@@ -503,9 +506,13 @@ def _compact_activity(data: dict) -> dict:
     Keeps the full ``summary`` (already small) and ``zoneList``, but compacts
     ``lapList`` items by dropping empty-valued keys and per-item fields that are
     constant or irrelevant for analysis. Also drops bulky top-level keys.
-    Deduplicates laps whose compacted item lists are identical — climbing
-    activities emit ``type=2`` and ``type=3`` laps that are item-for-item copies,
-    so dedup is keyed on ``lapItemList`` only (not the lap-level fields).
+
+    Collapses *adjacent* laps whose compacted item lists are identical —
+    climbing activities emit a ``type=2``/``type=3`` pair back-to-back that is
+    an item-for-item copy of the same segment. Dedup is deliberately limited to
+    consecutive laps so genuinely repeated work (e.g. two identical recovery
+    intervals separated by work laps in a HIIT session) is preserved rather
+    than silently merged. Empty item lists never count as duplicates.
 
     Typical reduction: ~125k chars -> ~15-25k chars (80-85%).
     """
@@ -513,7 +520,7 @@ def _compact_activity(data: dict) -> dict:
 
     if "lapList" in out:
         compacted_laps = []
-        seen_item_hashes: set[str] = set()
+        prev_item_hash: str | None = None
         for lap in out["lapList"]:
             new_lap = {k: v for k, v in lap.items() if k != "lapItemList"}
             new_lap["lapItemList"] = [
@@ -522,9 +529,15 @@ def _compact_activity(data: dict) -> dict:
                 for item in lap.get("lapItemList", [])
             ]
             item_hash = json.dumps(new_lap["lapItemList"], sort_keys=True)
-            if item_hash not in seen_item_hashes:
-                seen_item_hashes.add(item_hash)
-                compacted_laps.append(new_lap)
+            # Skip only a back-to-back copy that actually carries data (the
+            # climbing type=2/type=3 artifact). A lap whose items all compacted
+            # away (e.g. ``[{}]``) carries no content to dedup on, so never
+            # collapse those into each other.
+            has_content = any(item for item in new_lap["lapItemList"])
+            if has_content and item_hash == prev_item_hash:
+                continue
+            prev_item_hash = item_hash
+            compacted_laps.append(new_lap)
         out["lapList"] = compacted_laps
 
     return out

--- a/tests/test_post_release_review_fixes.py
+++ b/tests/test_post_release_review_fixes.py
@@ -1,0 +1,181 @@
+"""Tests for the review fixes applied after the v0.3 release.
+
+Covers:
+  1. _compact_activity: adjacent-only lap dedup preserves non-adjacent repeats
+  2. get_help: stays in sync with the registered MCP tool set (no drift)
+  3. get_stored_auth: env-token precedence vs. refreshable credentials
+  4. _env_int: malformed env value falls back instead of crashing at import
+  5. add_planned_workout: does not mutate the caller's program dict
+"""
+
+import asyncio
+
+import pytest
+
+from coros_mcp import coros_api
+from coros_mcp.server import _compact_activity, get_help, mcp
+
+# ---------------------------------------------------------------------------
+# 1. Adjacent-only lap dedup
+# ---------------------------------------------------------------------------
+
+class TestLapDedupAdjacentOnly:
+    def test_collapses_adjacent_climbing_copy(self):
+        items = [{"avgHr": 140, "distance": 500}]
+        data = {
+            "lapList": [
+                {"type": 2, "lapItemList": [dict(i) for i in items]},
+                {"type": 3, "lapItemList": [dict(i) for i in items]},  # back-to-back copy
+                {"type": 4, "lapItemList": [{"avgHr": 160, "distance": 600}]},
+            ]
+        }
+        out = _compact_activity(data)
+        assert [lap["type"] for lap in out["lapList"]] == [2, 4]
+
+    def test_preserves_non_adjacent_identical_laps(self):
+        """Two identical recovery intervals separated by work laps must survive."""
+        recovery = [{"avgHr": 110, "avgPower": 120}]
+        work = [{"avgHr": 175, "avgPower": 300}]
+        data = {
+            "lapList": [
+                {"lapIndex": 1, "lapItemList": [dict(i) for i in recovery]},
+                {"lapIndex": 2, "lapItemList": [dict(i) for i in work]},
+                {"lapIndex": 3, "lapItemList": [dict(i) for i in recovery]},  # same items, not adjacent
+            ]
+        }
+        out = _compact_activity(data)
+        assert [lap["lapIndex"] for lap in out["lapList"]] == [1, 2, 3]
+
+    def test_empty_item_lists_are_never_deduped(self):
+        data = {
+            "lapList": [
+                {"lapIndex": 1, "lapItemList": [{"avgPower": 0}]},  # compacts to []
+                {"lapIndex": 2, "lapItemList": [{"note": ""}]},     # compacts to []
+            ]
+        }
+        out = _compact_activity(data)
+        assert [lap["lapIndex"] for lap in out["lapList"]] == [1, 2]
+
+    def test_collapses_run_of_more_than_two_copies(self):
+        items = [{"avgHr": 140}]
+        data = {
+            "lapList": [
+                {"type": 2, "lapItemList": [dict(i) for i in items]},
+                {"type": 3, "lapItemList": [dict(i) for i in items]},
+                {"type": 5, "lapItemList": [dict(i) for i in items]},
+            ]
+        }
+        out = _compact_activity(data)
+        assert len(out["lapList"]) == 1
+        assert out["lapList"][0]["type"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. get_help stays in sync with the registry
+# ---------------------------------------------------------------------------
+
+def test_get_help_matches_registered_tools():
+    registered = {t.name for t in asyncio.run(mcp.list_tools())}
+    listed = {entry["name"] for entry in asyncio.run(get_help())["tools"]}
+    assert listed == registered, (
+        "get_help is out of sync with the registered MCP tools. "
+        f"Missing from get_help: {registered - listed}. "
+        f"Listed but not registered: {listed - registered}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. get_stored_auth env-token precedence
+# ---------------------------------------------------------------------------
+
+class TestGetStoredAuthPrecedence:
+    def _stored(self, token="stored-tok"):
+        return coros_api.StoredAuth(
+            access_token=token, user_id="u1", region="eu",
+            timestamp=0, mobile_access_token=None, mobile_login_payload=None,
+        )
+
+    def test_env_token_wins_when_no_credentials(self, monkeypatch):
+        monkeypatch.setenv("COROS_ACCESS_TOKEN", "env-tok")
+        monkeypatch.delenv("COROS_EMAIL", raising=False)
+        monkeypatch.delenv("COROS_PASSWORD", raising=False)
+        monkeypatch.setattr(coros_api, "_load_auth", lambda: self._stored())
+        monkeypatch.setattr(coros_api, "_is_token_valid", lambda a: True)
+        auth = coros_api.get_stored_auth()
+        assert auth is not None and auth.access_token == "env-tok"
+
+    def test_valid_stored_token_wins_over_env_when_credentials_present(self, monkeypatch):
+        monkeypatch.setenv("COROS_ACCESS_TOKEN", "stale-env-tok")
+        monkeypatch.setenv("COROS_EMAIL", "a@b.c")
+        monkeypatch.setenv("COROS_PASSWORD", "pw")
+        monkeypatch.setattr(coros_api, "_load_auth", lambda: self._stored("fresh-stored"))
+        monkeypatch.setattr(coros_api, "_is_token_valid", lambda a: True)
+        auth = coros_api.get_stored_auth()
+        # The freshly-minted stored token must take effect, not the stale env one.
+        assert auth is not None and auth.access_token == "fresh-stored"
+
+    def test_env_token_seeds_when_credentials_present_but_no_valid_stored(self, monkeypatch):
+        monkeypatch.setenv("COROS_ACCESS_TOKEN", "env-tok")
+        monkeypatch.setenv("COROS_EMAIL", "a@b.c")
+        monkeypatch.setenv("COROS_PASSWORD", "pw")
+        monkeypatch.setattr(coros_api, "_load_auth", lambda: None)
+        monkeypatch.setattr(coros_api, "_is_token_valid", lambda a: False)
+        auth = coros_api.get_stored_auth()
+        assert auth is not None and auth.access_token == "env-tok"
+
+    def test_returns_none_when_no_env_token_and_no_valid_stored(self, monkeypatch):
+        monkeypatch.delenv("COROS_ACCESS_TOKEN", raising=False)
+        monkeypatch.setenv("COROS_EMAIL", "a@b.c")
+        monkeypatch.setenv("COROS_PASSWORD", "pw")
+        monkeypatch.setattr(coros_api, "_load_auth", lambda: None)
+        monkeypatch.setattr(coros_api, "_is_token_valid", lambda a: False)
+        assert coros_api.get_stored_auth() is None
+
+
+# ---------------------------------------------------------------------------
+# 4. _env_int robustness
+# ---------------------------------------------------------------------------
+
+class TestEnvInt:
+    def test_valid_value(self, monkeypatch):
+        from coros_mcp.cache import sync
+        monkeypatch.setenv("COROS_STABLE_DAYS", "5")
+        assert sync._env_int("COROS_STABLE_DAYS", 2) == 5
+
+    def test_missing_uses_default(self, monkeypatch):
+        from coros_mcp.cache import sync
+        monkeypatch.delenv("COROS_STABLE_DAYS", raising=False)
+        assert sync._env_int("COROS_STABLE_DAYS", 2) == 2
+
+    def test_malformed_falls_back_without_raising(self, monkeypatch):
+        from coros_mcp.cache import sync
+        monkeypatch.setenv("COROS_STABLE_DAYS", "zwei")
+        assert sync._env_int("COROS_STABLE_DAYS", 2) == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. add_planned_workout does not mutate the caller's program
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_add_planned_workout_does_not_mutate_program(monkeypatch):
+    captured = {}
+
+    async def fake_post(auth, payload):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(coros_api, "_post_schedule_update", fake_post)
+
+    entity = {"idInPlan": 7, "happenDay": "20260613"}
+    program = {"name": "Run"}  # intentionally lacks idInPlan
+    auth = coros_api.StoredAuth(
+        access_token="t", user_id="u", region="eu", timestamp=0,
+        mobile_access_token=None, mobile_login_payload=None,
+    )
+
+    await coros_api.add_planned_workout(auth, entity, program)
+
+    # Caller's dict is untouched...
+    assert "idInPlan" not in program
+    # ...while the sent payload carries the resolved idInPlan.
+    assert captured["payload"]["programs"][0]["idInPlan"] == 7


### PR DESCRIPTION
Behebt die im Post-v0.3-Review gefundenen Punkte. Alle Änderungen mit Regressionstests abgesichert; `pytest` (121), `ruff` und `mypy` grün.

## Fixes

- **Lap-Dedup-Datenverlust** (`_compact_activity`): Dedup von global auf **adjazent** umgestellt. Nur das direkt aufeinanderfolgende Climbing-`type=2`/`type=3`-Paar wird kollabiert; echte, nicht benachbarte Wiederholungen (z. B. zwei identische Recovery-Intervalle in einem HIIT) bleiben erhalten. Laps, deren Items vollständig wegkompaktiert wurden, gelten nie als Duplikat.
- **Stale `COROS_ACCESS_TOKEN`** (`get_stored_auth`): Sind refreshbare Credentials gesetzt, gewinnt ein **gültiger gespeicherter** Token über einen abgelaufenen Env-Token. Damit wirkt ein per Auto-Login frisch erzeugter Token sofort, statt pro Call einen Fehlrequest + Re-Login zu verursachen. Der reine Env-Token-Use-Case bleibt unverändert.
- **Import-Crash** (`cache/sync`): Neuer Helper `_env_int()` fängt ein fehlerhaftes `COROS_STABLE_DAYS` ab (Warnung + Default) statt beim Modul-Import zu crashen.
- **Eingabe-Dict-Mutation** (`add_planned_workout`): kopiert das `program`-Dict statt es zu mutieren.

## Doku

- `list_activities`: `total_count` ist die lokale Cache-Anzahl und kann bis zum Full-Sync vom Server-Total abweichen — jetzt im Docstring vermerkt.

## Tests

- `tests/test_post_release_review_fixes.py`: deckt adjazentes Dedup, Env-Token-Präzedenz, `_env_int`, Non-Mutation ab.
- Zusätzlich ein **Drift-Guard**, der `get_help` gegen `mcp.list_tools()` abgleicht, damit künftige Tool-Änderungen die Hilfeliste nicht stillschweigend veralten lassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)