### PR TITLE
test: cover SQLite cache store and cached fetch wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ build/
 .ruff_cache/
 .pytest_cache/
 
+# Coverage
+.coverage
+coverage.xml
+htmlcov/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ coros-mcp = "coros_mcp.cli:main"
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
     "ruff>=0.9",
     "mypy>=1.10",
 ]

--- a/tests/test_cache_store.py
+++ b/tests/test_cache_store.py
@@ -1,0 +1,300 @@
+"""Direct SQLite round-trip tests for coros_mcp/cache/store.py.
+
+These exercise the real persistence layer against a temporary on-disk DB
+(CACHE_DB is monkeypatched per test), rather than mocking the store away.
+
+Covered:
+  * upsert/get round trips for daily, sleep, and activity records
+  * INSERT OR REPLACE upsert semantics (latest write wins)
+  * inclusive range-query boundaries and result ordering
+  * MIN/MAX date helpers on empty and populated tables
+  * _activity_start_day timestamp parsing (10-/13-digit, encoded strings,
+    timezone date-boundary crossing, and unparseable input)
+  * upsert_activities skipping rows with unparseable start_time
+  * cache_status counts and coverage
+  * init_db idempotency
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from coros_mcp.cache import store
+from coros_mcp.models import ActivitySummary, DailyRecord, SleepPhases, SleepRecord
+
+TZ_PLUS8 = timezone(timedelta(hours=8))
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    """Point store.CACHE_DB at a fresh temp file and create the schema."""
+    db = tmp_path / "cache.db"
+    monkeypatch.setattr(store, "CACHE_DB", db)
+    store.init_db()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+def daily(date: str, **kw) -> DailyRecord:
+    return DailyRecord(date=date, **kw)
+
+
+def sleep(date: str, **kw) -> SleepRecord:
+    return SleepRecord(date=date, **kw)
+
+
+def activity(activity_id: str, start_time: str | None, **kw) -> ActivitySummary:
+    return ActivitySummary(activity_id=activity_id, start_time=start_time, **kw)
+
+
+def secs(dt: datetime) -> str:
+    """UTC datetime → 10-digit unix-seconds string."""
+    return str(int(dt.timestamp()))
+
+
+def millis(dt: datetime) -> str:
+    """UTC datetime → 13-digit unix-millis string."""
+    return str(int(dt.timestamp() * 1000))
+
+
+# ---------------------------------------------------------------------------
+# init_db
+# ---------------------------------------------------------------------------
+
+class TestInitDb:
+    def test_idempotent(self, temp_db):
+        # Second call must not raise (CREATE TABLE IF NOT EXISTS).
+        store.init_db()
+        store.init_db()
+        assert store.cache_status()["daily_records"]["count"] == 0
+
+    def test_creates_parent_directory(self, tmp_path, monkeypatch):
+        nested = tmp_path / "a" / "b" / "cache.db"
+        monkeypatch.setattr(store, "CACHE_DB", nested)
+        store.init_db()
+        assert nested.exists()
+
+
+# ---------------------------------------------------------------------------
+# Daily records
+# ---------------------------------------------------------------------------
+
+class TestDailyRecords:
+    def test_round_trip_preserves_fields(self, temp_db):
+        rec = daily("20260101", rhr=48, training_load=320, vo2max=55, stamina_level=3.2)
+        store.upsert_daily_records([rec])
+        got = store.get_daily_records("20260101", "20260101")
+        assert len(got) == 1
+        assert got[0] == rec  # full pydantic equality, all fields survive JSON round trip
+
+    def test_empty_input_is_noop(self, temp_db):
+        store.upsert_daily_records([])
+        assert store.get_daily_records("00000000", "99999999") == []
+
+    def test_range_is_inclusive_on_both_ends(self, temp_db):
+        store.upsert_daily_records([daily(d) for d in ("20260101", "20260102", "20260103")])
+        got = store.get_daily_records("20260101", "20260103")
+        assert [r.date for r in got] == ["20260101", "20260102", "20260103"]
+
+    def test_range_excludes_outside_dates(self, temp_db):
+        store.upsert_daily_records([daily(d) for d in ("20251231", "20260101", "20260104")])
+        got = store.get_daily_records("20260101", "20260103")
+        assert [r.date for r in got] == ["20260101"]
+
+    def test_results_ordered_ascending(self, temp_db):
+        store.upsert_daily_records([daily(d) for d in ("20260103", "20260101", "20260102")])
+        got = store.get_daily_records("20260101", "20260103")
+        assert [r.date for r in got] == ["20260101", "20260102", "20260103"]
+
+    def test_upsert_replaces_existing_date(self, temp_db):
+        store.upsert_daily_records([daily("20260101", rhr=50)])
+        store.upsert_daily_records([daily("20260101", rhr=42)])
+        got = store.get_daily_records("20260101", "20260101")
+        assert len(got) == 1  # not duplicated
+        assert got[0].rhr == 42  # latest write wins
+
+    def test_min_max_empty(self, temp_db):
+        assert store.get_min_daily_date() is None
+        assert store.get_max_daily_date() is None
+
+    def test_min_max_populated(self, temp_db):
+        store.upsert_daily_records([daily(d) for d in ("20260105", "20260101", "20260110")])
+        assert store.get_min_daily_date() == "20260101"
+        assert store.get_max_daily_date() == "20260110"
+
+
+# ---------------------------------------------------------------------------
+# Sleep records
+# ---------------------------------------------------------------------------
+
+class TestSleepRecords:
+    def test_round_trip_with_nested_phases(self, temp_db):
+        rec = sleep(
+            "20260101",
+            total_duration_minutes=455,
+            phases=SleepPhases(deep_minutes=90, light_minutes=250, rem_minutes=100, awake_minutes=15),
+            avg_hr=52,
+            quality_score=88,
+        )
+        store.upsert_sleep_records([rec])
+        got = store.get_sleep_records("20260101", "20260101")
+        assert got == [rec]
+        assert got[0].phases.deep_minutes == 90
+
+    def test_range_and_order(self, temp_db):
+        store.upsert_sleep_records([sleep(d) for d in ("20260103", "20260101", "20260102")])
+        got = store.get_sleep_records("20260101", "20260102")
+        assert [r.date for r in got] == ["20260101", "20260102"]
+
+    def test_upsert_replaces(self, temp_db):
+        store.upsert_sleep_records([sleep("20260101", quality_score=10)])
+        store.upsert_sleep_records([sleep("20260101", quality_score=99)])
+        got = store.get_sleep_records("20260101", "20260101")
+        assert len(got) == 1
+        assert got[0].quality_score == 99
+
+    def test_min_max(self, temp_db):
+        assert store.get_min_sleep_date() is None
+        store.upsert_sleep_records([sleep(d) for d in ("20260102", "20260108")])
+        assert store.get_min_sleep_date() == "20260102"
+        assert store.get_max_sleep_date() == "20260108"
+
+
+# ---------------------------------------------------------------------------
+# _activity_start_day — timestamp/date parsing
+# ---------------------------------------------------------------------------
+
+class TestActivityStartDay:
+    def test_seconds_with_fixed_tz(self, monkeypatch):
+        monkeypatch.setattr(store, "_LOCAL_TZ", TZ_PLUS8)
+        # 2026-01-01 02:00 UTC → 10:00 on 2026-01-01 in +8
+        ts = secs(datetime(2026, 1, 1, 2, 0, tzinfo=UTC))
+        assert store._activity_start_day(activity("a", ts)) == "20260101"
+
+    def test_seconds_crosses_date_boundary_with_tz(self, monkeypatch):
+        monkeypatch.setattr(store, "_LOCAL_TZ", TZ_PLUS8)
+        # 2026-01-01 20:00 UTC → 04:00 on 2026-01-02 in +8
+        ts = secs(datetime(2026, 1, 1, 20, 0, tzinfo=UTC))
+        assert store._activity_start_day(activity("a", ts)) == "20260102"
+
+    def test_milliseconds_13_digits(self, monkeypatch):
+        monkeypatch.setattr(store, "_LOCAL_TZ", TZ_PLUS8)
+        ts = millis(datetime(2026, 1, 1, 2, 0, tzinfo=UTC))
+        assert len(ts) == 13
+        assert store._activity_start_day(activity("a", ts)) == "20260101"
+
+    def test_seconds_falls_back_to_system_tz_when_unset(self, monkeypatch):
+        monkeypatch.setattr(store, "_LOCAL_TZ", None)
+        dt = datetime(2026, 6, 13, 12, 0, tzinfo=UTC)
+        ts = secs(dt)
+        expected = datetime.fromtimestamp(int(ts)).strftime("%Y%m%d")
+        assert store._activity_start_day(activity("a", ts)) == expected
+
+    def test_encoded_yyyymmdd_string(self):
+        # 8 numeric digits: not 10/13 → treated as already-encoded date prefix.
+        assert store._activity_start_day(activity("a", "20260101")) == "20260101"
+
+    def test_encoded_yyyymmddhhmmss_string(self):
+        # 14 numeric digits → first 8 used as the date.
+        assert store._activity_start_day(activity("a", "20260101153000")) == "20260101"
+
+    def test_empty_start_time_returns_blank(self):
+        assert store._activity_start_day(activity("a", None)) == ""
+        assert store._activity_start_day(activity("a", "")) == ""
+
+    def test_non_numeric_junk_returns_blank(self):
+        assert store._activity_start_day(activity("a", "not-a-date")) == ""
+
+
+# ---------------------------------------------------------------------------
+# Activities — upsert / get
+# ---------------------------------------------------------------------------
+
+class TestActivities:
+    def _acts_on(self, *dates):
+        """Activities whose start_time is noon-UTC on the given YYYYMMDD dates."""
+        out = []
+        for i, d in enumerate(dates):
+            dt = datetime.strptime(d, "%Y%m%d").replace(hour=12, tzinfo=UTC)
+            out.append(activity(f"act{i}", secs(dt), name=f"Run {i}", sport_type=100))
+        return out
+
+    @pytest.fixture(autouse=True)
+    def _utc_tz(self, monkeypatch):
+        # Pin tz so noon-UTC stays on the same calendar day for indexing.
+        monkeypatch.setattr(store, "_LOCAL_TZ", UTC)
+
+    def test_round_trip(self, temp_db):
+        acts = self._acts_on("20260101")
+        store.upsert_activities(acts)
+        got = store.get_activities("20260101", "20260101")
+        assert got == acts
+
+    def test_get_ordered_descending_by_day(self, temp_db):
+        store.upsert_activities(self._acts_on("20260101", "20260103", "20260102"))
+        got = store.get_activities("20260101", "20260103")
+        # store.get_activities orders by start_day DESC (newest first)
+        days = [store._activity_start_day(a) for a in got]
+        assert days == ["20260103", "20260102", "20260101"]
+
+    def test_range_filtering(self, temp_db):
+        store.upsert_activities(self._acts_on("20251231", "20260101", "20260105"))
+        got = store.get_activities("20260101", "20260102")
+        assert [a.activity_id for a in got] == ["act1"]
+
+    def test_upsert_replaces_by_activity_id(self, temp_db):
+        dt = datetime(2026, 1, 1, 12, tzinfo=UTC)
+        store.upsert_activities([activity("same", secs(dt), name="old")])
+        store.upsert_activities([activity("same", secs(dt), name="new")])
+        got = store.get_activities("20260101", "20260101")
+        assert len(got) == 1
+        assert got[0].name == "new"
+
+    def test_skips_unparseable_start_time(self, temp_db, caplog):
+        good = self._acts_on("20260101")[0]
+        bad = activity("bad", "garbage")
+        store.upsert_activities([good, bad])
+        all_acts = store.get_activities("00000000", "99999999")
+        assert {a.activity_id for a in all_acts} == {"act0"}  # 'bad' was skipped
+        assert "Skipping activity bad" in caplog.text
+
+    def test_all_unparseable_is_noop(self, temp_db):
+        store.upsert_activities([activity("x", None), activity("y", "")])
+        assert store.get_activities("00000000", "99999999") == []
+
+    def test_min_max_activity_date(self, temp_db):
+        assert store.get_min_activity_date() is None
+        store.upsert_activities(self._acts_on("20260105", "20260101", "20260110"))
+        assert store.get_min_activity_date() == "20260101"
+        assert store.get_max_activity_date() == "20260110"
+
+
+# ---------------------------------------------------------------------------
+# cache_status
+# ---------------------------------------------------------------------------
+
+class TestCacheStatus:
+    def test_empty_db(self, tmp_path, monkeypatch):
+        db = tmp_path / "cache.db"
+        monkeypatch.setattr(store, "CACHE_DB", db)
+        # cache_status calls init_db() itself — no prior schema needed.
+        status = store.cache_status()
+        for key in ("daily_records", "sleep_records", "activities"):
+            assert status[key] == {"count": 0, "from": None, "to": None}
+        assert status["db_path"] == str(db)
+
+    def test_populated_counts_and_coverage(self, temp_db, monkeypatch):
+        monkeypatch.setattr(store, "_LOCAL_TZ", UTC)  # deterministic activity indexing
+        store.upsert_daily_records([daily(d) for d in ("20260101", "20260102")])
+        store.upsert_sleep_records([sleep("20260101")])
+        dt = datetime(2026, 1, 3, 12, tzinfo=UTC)
+        store.upsert_activities([activity("a", secs(dt))])
+
+        status = store.cache_status()
+        assert status["daily_records"] == {"count": 2, "from": "20260101", "to": "20260102"}
+        assert status["sleep_records"] == {"count": 1, "from": "20260101", "to": "20260101"}
+        assert status["activities"]["count"] == 1
+        assert status["activities"]["from"] == "20260103"

--- a/tests/test_cache_sync_integration.py
+++ b/tests/test_cache_sync_integration.py
@@ -1,0 +1,346 @@
+"""Integration tests for the cached fetch wrappers in coros_mcp/cache/sync.py.
+
+Unlike test_cache_sync.py (which unit-tests _resolve_fetch_range / sync_all in
+isolation with everything mocked), these drive the *real* SQLite store through
+fetch_*_cached() while mocking only the network layer (coros_api.*). This proves
+the cache actually short-circuits the API, fetches only uncached ranges, chunks
+long ranges, paginates activities, and persists results.
+
+_today() is pinned to 20260613 so the STABLE_AFTER_DAYS=2 cutoff is 20260611;
+test ranges sit safely in the historical (stable) zone unless stated otherwise.
+asyncio.sleep is neutralised so the inter-chunk/inter-page pacing doesn't slow
+the suite.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from coros_mcp.cache import store, sync
+from coros_mcp.models import ActivitySummary, DailyRecord, SleepRecord, StoredAuth
+
+TODAY = "20260613"
+AUTH = StoredAuth(access_token="t", user_id="u", region="eu", timestamp=0)
+
+
+@pytest.fixture
+def wired(tmp_path, monkeypatch):
+    """Real temp DB + pinned today + no-op sleep. Returns the db path."""
+    db = tmp_path / "cache.db"
+    monkeypatch.setattr(store, "CACHE_DB", db)
+    monkeypatch.setattr(store, "_LOCAL_TZ", UTC)
+    monkeypatch.setattr(sync, "_today", lambda: TODAY)
+
+    async def _no_sleep(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(sync.asyncio, "sleep", _no_sleep)
+    store.init_db()
+    return db
+
+
+def daily_range(start: str, end: str) -> list[DailyRecord]:
+    """One DailyRecord per day in [start, end]."""
+    out, cur = [], start
+    while cur <= end:
+        out.append(DailyRecord(date=cur, rhr=50))
+        cur = sync._date_add(cur, 1)
+    return out
+
+
+def act_on(activity_id: str, day: str) -> ActivitySummary:
+    dt = datetime.strptime(day, "%Y%m%d").replace(hour=12, tzinfo=UTC)
+    return ActivitySummary(activity_id=activity_id, start_time=str(int(dt.timestamp())))
+
+
+# ---------------------------------------------------------------------------
+# fetch_daily_records_cached
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestFetchDailyCached:
+    async def test_cold_cache_fetches_and_persists(self, wired, monkeypatch):
+        calls = []
+
+        async def fake(auth, s, e):
+            calls.append((s, e))
+            return daily_range(s, e)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", fake)
+        got = await sync.fetch_daily_records_cached(AUTH, "20260101", "20260110")
+
+        assert [r.date for r in got] == [sync._date_add("20260101", i) for i in range(10)]
+        assert calls == [("20260101", "20260110")]
+        # Persisted: a direct store read sees the same rows.
+        assert len(store.get_daily_records("20260101", "20260110")) == 10
+
+    async def test_second_call_fully_covered_skips_api(self, wired, monkeypatch):
+        calls = []
+
+        async def fake(auth, s, e):
+            calls.append((s, e))
+            return daily_range(s, e)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", fake)
+        await sync.fetch_daily_records_cached(AUTH, "20260101", "20260110")
+        await sync.fetch_daily_records_cached(AUTH, "20260103", "20260108")
+
+        assert len(calls) == 1  # second request served entirely from cache
+
+    async def test_tail_gap_fetches_only_uncached_tail(self, wired, monkeypatch):
+        calls = []
+
+        async def fake(auth, s, e):
+            calls.append((s, e))
+            return daily_range(s, e)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", fake)
+        await sync.fetch_daily_records_cached(AUTH, "20260101", "20260110")
+        calls.clear()
+        await sync.fetch_daily_records_cached(AUTH, "20260101", "20260115")
+
+        # Only the uncached tail (11th onward) is fetched, not the whole range.
+        assert len(calls) == 1
+        fetch_from, fetch_to = calls[0]
+        assert fetch_from == "20260111"
+        assert fetch_to == "20260115"
+
+    async def test_long_range_is_chunked(self, wired, monkeypatch):
+        calls = []
+
+        async def fake(auth, s, e):
+            calls.append((s, e))
+            return daily_range(s, e)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", fake)
+        # 200 days > API_CHUNK_DAYS (84) → expect 3 chunks (84 + 84 + 32).
+        end = sync._date_add("20260101", 199)
+        await sync.fetch_daily_records_cached(AUTH, "20260101", end)
+
+        assert len(calls) == 3
+        # Chunks must be contiguous and non-overlapping.
+        assert calls[0][0] == "20260101"
+        for prev, nxt in zip(calls, calls[1:], strict=False):
+            assert sync._date_add(prev[1], 1) == nxt[0]
+        assert calls[-1][1] == end
+        # Every day landed in the cache exactly once.
+        assert len(store.get_daily_records("20260101", end)) == 200
+
+    async def test_empty_api_result_returns_empty_without_crash(self, wired, monkeypatch):
+        async def fake(auth, s, e):
+            return []
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", fake)
+        got = await sync.fetch_daily_records_cached(AUTH, "20260101", "20260110")
+        assert got == []
+        assert store.get_max_daily_date() is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_sleep_cached
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestFetchSleepCached:
+    async def test_cold_then_cached(self, wired, monkeypatch):
+        calls = []
+
+        async def fake(auth, s, e):
+            calls.append((s, e))
+            return [SleepRecord(date=s)]
+
+        monkeypatch.setattr(sync.coros_api, "fetch_sleep", fake)
+        await sync.fetch_sleep_cached(AUTH, "20260101", "20260101")
+        got = await sync.fetch_sleep_cached(AUTH, "20260101", "20260101")
+
+        assert len(calls) == 1
+        assert [r.date for r in got] == ["20260101"]
+
+
+# ---------------------------------------------------------------------------
+# fetch_activities_cached — pagination + page exhaustion
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestFetchActivitiesCached:
+    async def test_exhausts_all_api_pages(self, wired, monkeypatch):
+        # 250 activities across the range, API serves 100 per page → 3 pages.
+        days = [sync._date_add("20260101", i) for i in range(250)]
+        all_acts = [act_on(f"a{i}", d) for i, d in enumerate(days)]
+        seen_pages = []
+
+        async def fake(auth, s, e, page, size):
+            seen_pages.append(page)
+            start = (page - 1) * size
+            return all_acts[start:start + size], len(all_acts)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_activities", fake)
+        end = days[-1]
+        _, total = await sync.fetch_activities_cached(AUTH, "20260101", end, page=1, size=30)
+
+        assert seen_pages == [1, 2, 3]  # all pages pulled
+        assert total == 250  # full set cached
+        assert len(store.get_activities("20260101", end)) == 250
+
+    async def test_local_pagination_slices_cached_results(self, wired, monkeypatch):
+        days = [sync._date_add("20260101", i) for i in range(50)]
+        all_acts = [act_on(f"a{i}", d) for i, d in enumerate(days)]
+
+        async def fake(auth, s, e, page, size):
+            start = (page - 1) * size
+            return all_acts[start:start + size], len(all_acts)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_activities", fake)
+        end = days[-1]
+
+        page1, total = await sync.fetch_activities_cached(AUTH, "20260101", end, page=1, size=20)
+        page2, _ = await sync.fetch_activities_cached(AUTH, "20260101", end, page=2, size=20)
+        page3, _ = await sync.fetch_activities_cached(AUTH, "20260101", end, page=3, size=20)
+
+        assert total == 50
+        assert (len(page1), len(page2), len(page3)) == (20, 20, 10)
+        # Pages are disjoint and ordered (store returns start_day DESC).
+        ids = [a.activity_id for a in page1 + page2 + page3]
+        assert len(set(ids)) == 50
+
+    async def test_second_call_in_stable_range_skips_api(self, wired, monkeypatch):
+        days = [sync._date_add("20260101", i) for i in range(10)]
+        all_acts = [act_on(f"a{i}", d) for i, d in enumerate(days)]
+        call_count = 0
+
+        async def fake(auth, s, e, page, size):
+            nonlocal call_count
+            call_count += 1
+            return all_acts, len(all_acts)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_activities", fake)
+        end = days[-1]
+        await sync.fetch_activities_cached(AUTH, "20260101", end)
+        before = call_count
+        await sync.fetch_activities_cached(AUTH, "20260101", end)
+        assert call_count == before  # fully covered, no extra API hits
+
+
+# ---------------------------------------------------------------------------
+# Unstable-window re-fetch (recent data always re-pulled)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestUnstableWindowRefetch:
+    async def test_recent_range_refetched_even_when_cached(self, wired, monkeypatch):
+        # cutoff = TODAY - 2 = 20260611. A range touching today is "unstable"
+        # and must be re-fetched on every call to pick up delayed syncs.
+        calls = []
+
+        async def fake(auth, s, e):
+            calls.append((s, e))
+            return daily_range(s, e)
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", fake)
+        await sync.fetch_daily_records_cached(AUTH, "20260610", TODAY)
+        calls.clear()
+        await sync.fetch_daily_records_cached(AUTH, "20260610", TODAY)
+
+        assert calls, "recent (unstable) range should be re-fetched, not served from cache"
+        # Re-fetch starts no earlier than the stable cutoff (20260611).
+        assert calls[0][0] >= "20260611"
+
+
+# ---------------------------------------------------------------------------
+# sync_all — full backfill: error resilience + progress reporting
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSyncAll:
+    async def test_continues_and_records_errors_when_one_type_fails(self, wired, monkeypatch):
+        async def daily_boom(auth, s, e):
+            raise RuntimeError("daily endpoint down")
+
+        async def sleep_ok(auth, s, e):
+            return [SleepRecord(date=s)]
+
+        async def acts_ok(auth, s, e, page, size):
+            return [act_on("a0", s)], 1
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", daily_boom)
+        monkeypatch.setattr(sync.coros_api, "fetch_sleep", sleep_ok)
+        monkeypatch.setattr(sync.coros_api, "fetch_activities", acts_ok)
+
+        stats = await sync.sync_all(AUTH, start_day="20260101", end_day="20260105")
+
+        # daily failed but sleep + activities still ran and persisted.
+        assert stats["daily"] == 0
+        assert any("daily" in err for err in stats["errors"])
+        assert stats["sleep"] >= 1
+        assert stats["activities"] >= 1
+        assert store.get_max_sleep_date() == "20260101"
+        assert "cache" in stats  # final cache_status() attached
+
+    async def test_all_types_fail_records_three_errors_and_completes(self, wired, monkeypatch):
+        async def boom_daily(auth, s, e):
+            raise RuntimeError("daily down")
+
+        async def boom_sleep(auth, s, e):
+            raise RuntimeError("sleep down")
+
+        async def boom_acts(auth, s, e, page, size):
+            raise RuntimeError("activities down")
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", boom_daily)
+        monkeypatch.setattr(sync.coros_api, "fetch_sleep", boom_sleep)
+        monkeypatch.setattr(sync.coros_api, "fetch_activities", boom_acts)
+
+        stats = await sync.sync_all(AUTH, "20260101", "20260105")
+
+        # Every type's error is captured, sync still returns cleanly with zero counts.
+        assert stats["daily"] == 0 and stats["sleep"] == 0 and stats["activities"] == 0
+        assert any("daily" in e for e in stats["errors"])
+        assert any("sleep" in e for e in stats["errors"])
+        assert any("activities" in e for e in stats["errors"])
+
+    async def test_progress_callback_receives_messages(self, wired, monkeypatch):
+        async def ok_daily(auth, s, e):
+            return []
+
+        async def ok_sleep(auth, s, e):
+            return []
+
+        async def ok_acts(auth, s, e, page, size):
+            return [], 0
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", ok_daily)
+        monkeypatch.setattr(sync.coros_api, "fetch_sleep", ok_sleep)
+        monkeypatch.setattr(sync.coros_api, "fetch_activities", ok_acts)
+
+        messages = []
+
+        async def on_progress(msg):
+            messages.append(msg)
+
+        await sync.sync_all(AUTH, "20260101", "20260105", on_progress=on_progress)
+
+        assert messages, "on_progress should have been called"
+        assert messages[-1] == "done"
+        assert any("syncing" in m for m in messages)
+
+    async def test_happy_path_persists_all_three_types(self, wired, monkeypatch):
+        async def ok_daily(auth, s, e):
+            return daily_range(s, e)
+
+        async def ok_sleep(auth, s, e):
+            return [SleepRecord(date=s)]
+
+        async def ok_acts(auth, s, e, page, size):
+            return [act_on("a0", s)], 1
+
+        monkeypatch.setattr(sync.coros_api, "fetch_daily_records", ok_daily)
+        monkeypatch.setattr(sync.coros_api, "fetch_sleep", ok_sleep)
+        monkeypatch.setattr(sync.coros_api, "fetch_activities", ok_acts)
+
+        stats = await sync.sync_all(AUTH, "20260101", "20260105")
+
+        assert stats["errors"] == []
+        assert stats["daily"] == 5  # one record per day, single chunk
+        assert stats["sleep"] == 1
+        assert stats["activities"] == 1
+        assert len(store.get_daily_records("20260101", "20260105")) == 5

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,43 @@
+"""Tests for coros_mcp/cache/utils.py display/timezone helpers."""
+
+from datetime import timedelta, timezone
+
+from coros_mcp.cache import utils
+
+TZ_PLUS8 = timezone(timedelta(hours=8))
+
+
+class TestParseTzOffset:
+    def test_iso_style_with_minutes(self):
+        assert utils._parse_tz_offset("+05:30").utcoffset(None) == timedelta(hours=5, minutes=30)
+
+    def test_negative_iso_style(self):
+        assert utils._parse_tz_offset("-05:30").utcoffset(None) == timedelta(hours=-5, minutes=-30)
+
+    def test_integer_hours(self):
+        assert utils._parse_tz_offset("8").utcoffset(None) == timedelta(hours=8)
+
+    def test_float_hours(self):
+        assert utils._parse_tz_offset("5.5").utcoffset(None) == timedelta(hours=5, minutes=30)
+
+    def test_negative_float_hours(self):
+        assert utils._parse_tz_offset("-5.75").utcoffset(None) == timedelta(hours=-5, minutes=-45)
+
+
+class TestFmtLocalTime:
+    def test_formats_with_fixed_tz(self, monkeypatch):
+        monkeypatch.setattr(utils, "LOCAL_TZ", TZ_PLUS8)
+        # 2025-03-16 07:02:03 in +8 (the docstring example).
+        assert utils.fmt_local_time("1742079723") == "2025-03-16 07:02:03"
+
+    def test_falls_back_to_system_tz(self, monkeypatch):
+        from datetime import datetime
+        monkeypatch.setattr(utils, "LOCAL_TZ", None)
+        expected = datetime.fromtimestamp(1742079723).strftime("%Y-%m-%d %H:%M:%S")
+        assert utils.fmt_local_time("1742079723") == expected
+
+    def test_non_numeric_returned_unchanged(self):
+        assert utils.fmt_local_time("not-a-number") == "not-a-number"
+
+    def test_none_returns_none(self):
+        assert utils.fmt_local_time(None) is None


### PR DESCRIPTION
## Summary

The `coros_mcp/cache` package previously had only mocked unit tests for the range-resolution logic. The actual SQLite persistence layer (`store.py`) was **completely untested** and the cached fetch wrappers in `sync.py` were never exercised end to end against a real database.

This PR adds three test modules that drive the **real** SQLite store (via a per-test temporary `CACHE_DB`), mocking only the network layer.

**Coverage of `coros_mcp.cache`: 54% → 99%** (121 → 175 tests).

| Module | before | after |
|---|---|---|
| `store.py` | 35% | **100%** |
| `sync.py` | 66% | **99%** |
| `utils.py` | 71% | **100%** |

## What's covered

**`tests/test_cache_store.py`** — real round-trips against a temp DB:
- upsert/get for daily/sleep/activities, `INSERT OR REPLACE` upsert semantics (latest-write-wins, no duplicates)
- inclusive range boundaries, result ordering (daily ASC, activities DESC)
- MIN/MAX date helpers on empty and populated tables
- `_activity_start_day`: 10-digit seconds, 13-digit millis, encoded `YYYYMMDD(HHMMSS)` strings, **tz date-boundary crossing**, empty/unparseable input
- `upsert_activities` skips unparseable `start_time`; `cache_status`; `init_db` idempotency

**`tests/test_cache_sync_integration.py`** — cached wrappers end to end:
- cold-cache fetch+persist; second call served fully from cache (no API hit)
- tail-gap fetches only the uncached remainder
- long-range **chunking** (200 days → 3 contiguous, non-overlapping chunks)
- activity **pagination** / page exhaustion + local slice pagination
- unstable-window re-fetch (recent data re-pulled despite cache)
- `sync_all` error resilience (one/all data types fail → errors recorded, sync continues) + `on_progress` reporting

**`tests/test_cache_utils.py`** — `_parse_tz_offset` and `fmt_local_time`.

## Notes
- Only `sync.py:111` remains uncovered — an unreachable defensive branch in `_fetch_start` (its only caller guarantees `max_cached is not None`).
- No production code changed; tests only.

## Test plan
- [x] `pytest tests/` — 175 passed
- [x] `ruff check tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)