### PR TITLE
fix: malformed COROS_TIMEZONE crashes the server at import

### DIFF
--- a/coros_mcp/cache/utils.py
+++ b/coros_mcp/cache/utils.py
@@ -1,8 +1,11 @@
 """Shared utilities for the cache package."""
 
+import logging
 import os
 import re
 from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_tz_offset(value: str) -> timezone:
@@ -30,8 +33,27 @@ def _parse_tz_offset(value: str) -> timezone:
 # Local timezone for display formatting.
 # Set COROS_TIMEZONE to your UTC offset in hours (e.g. "8", "-5", "5.5", "+05:30").
 # Defaults to the system local timezone when unset.
-_tz_offset = os.getenv("COROS_TIMEZONE")
-LOCAL_TZ: timezone | None = _parse_tz_offset(_tz_offset) if _tz_offset is not None else None
+def _init_local_tz() -> timezone | None:
+    """Resolve LOCAL_TZ from COROS_TIMEZONE, tolerating a malformed value.
+
+    Runs at import time, so a bad value must not raise — that would crash the
+    whole MCP server with an opaque traceback. A malformed offset logs a
+    warning and falls back to the system local timezone (None), matching the
+    "unset" behavior.
+    """
+    raw = os.getenv("COROS_TIMEZONE")
+    if raw is None:
+        return None
+    try:
+        return _parse_tz_offset(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid COROS_TIMEZONE=%r; falling back to system local timezone.", raw
+        )
+        return None
+
+
+LOCAL_TZ: timezone | None = _init_local_tz()
 
 
 def fmt_local_time(unix_secs: str | None) -> str | None:

--- a/tests/test_post_release_review_fixes.py
+++ b/tests/test_post_release_review_fixes.py
@@ -6,6 +6,7 @@ Covers:
   3. get_stored_auth: env-token precedence vs. refreshable credentials
   4. _env_int: malformed env value falls back instead of crashing at import
   5. add_planned_workout: does not mutate the caller's program dict
+  6. _init_local_tz: malformed COROS_TIMEZONE falls back instead of crashing
 """
 
 import asyncio
@@ -179,3 +180,30 @@ async def test_add_planned_workout_does_not_mutate_program(monkeypatch):
     assert "idInPlan" not in program
     # ...while the sent payload carries the resolved idInPlan.
     assert captured["payload"]["programs"][0]["idInPlan"] == 7
+
+
+# ---------------------------------------------------------------------------
+# 6. LOCAL_TZ robustness against a malformed COROS_TIMEZONE
+# ---------------------------------------------------------------------------
+
+class TestLocalTzInit:
+    """_init_local_tz() drives the module-level LOCAL_TZ at import. Exercise it
+    directly (no module reload) so a malformed COROS_TIMEZONE is proven not to
+    raise — at import time a raise would crash the whole MCP server."""
+
+    def test_malformed_timezone_falls_back_without_raising(self, monkeypatch):
+        from coros_mcp.cache import utils
+        monkeypatch.setenv("COROS_TIMEZONE", "not-a-tz")
+        assert utils._init_local_tz() is None
+
+    def test_valid_timezone_parsed(self, monkeypatch):
+        from datetime import timedelta, timezone
+
+        from coros_mcp.cache import utils
+        monkeypatch.setenv("COROS_TIMEZONE", "+05:30")
+        assert utils._init_local_tz() == timezone(timedelta(hours=5, minutes=30))
+
+    def test_unset_timezone_is_none(self, monkeypatch):
+        from coros_mcp.cache import utils
+        monkeypatch.delenv("COROS_TIMEZONE", raising=False)
+        assert utils._init_local_tz() is None


### PR DESCRIPTION
## Problem

Beim erneuten Komplett-Review ist ein Import-Time-Crash aufgefallen, der zur selben Fehlerklasse gehört wie der bereits in #34 behobene `COROS_STABLE_DAYS`-Fall — aber übersehen wurde.

`LOCAL_TZ` wird in `cache/utils.py` auf Modulebene über `_parse_tz_offset()` berechnet. Bei einem ungültigen `COROS_TIMEZONE` (z. B. `foo` → `float("foo")`) wirft das `ValueError` und reißt den **gesamten MCP-Server** beim Import mit opakem Traceback um — betrifft `coros-mcp serve`, `sync` und `cache-status`.

## Fix

Auflösung in `_init_local_tz()` gekapselt: ungültiger Wert → Warnung + Fallback auf System-Zeitzone (`None`), identisch zum „nicht gesetzt"-Verhalten. Konsistent mit dem `_env_int()`-Fix aus #34.

## Tests

`_init_local_tz()` direkt getestet (malformed / valid / unset) — ohne fragile Modul-Reloads. Manuell verifiziert:

```
$ COROS_TIMEZONE=totally-bogus python -c "import coros_mcp.server; ..."
Invalid COROS_TIMEZONE='totally-bogus'; falling back to system local timezone.
import OK, LOCAL_TZ = None
```

178 Tests grün, ruff + mypy sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)