### PR TITLE
docs + feat: clarify mobile auth fields and add opt-in token verification (#47, #48, #49)

### DIFF
--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -173,9 +173,21 @@ async def _mobile_login(email: str, password: str, region: str = "eu") -> tuple[
         "hasHrCalibrated": 0,
         "kbValidity": 0,
         "pwd": _mobile_encrypt(_md5(password), app_key) + "\n",
+        # Device SIM/locale telemetry captured from a real login, NOT the Coros
+        # account region: "<MCC>|<device timezone>|<locale>" (310 = US SIM MCC of
+        # the capture emulator). Account region routing is done by the base URL
+        # (apieu vs apius) above; this field is not validated against the account
+        # — an EU account logs in with MCC 310 and gets EU data. Do not make it
+        # region-dependent without a real US-region capture confirming the format.
         "region": "310|Europe/Berlin|US",
         "skipValidation": False,
     }
+    # Hardcoded Android device fingerprint captured from a working Coros mobile
+    # app login (mitmproxy). If Coros starts rejecting stale clients (e.g. a
+    # "Parameter input error" or version-blocked response on mobile login), these
+    # values must be refreshed from a current APK / a fresh app-login capture:
+    # appVersion/versionCode/systemVersion track the app+OS build, mobileName is
+    # the device model triple. There is no auto-update path — this is a manual bump.
     yfheader = json.dumps({
         "appVersion": 1125917087236096,
         "clientType": 1,

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -407,6 +407,26 @@ def _auth_headers(auth: StoredAuth) -> dict:
     }
 
 
+async def verify_web_token(auth: StoredAuth) -> None:
+    """Confirm with Coros that the stored web access token is still accepted.
+
+    Performs a single GET against the dashboard endpoint — the cheapest
+    authenticated read — and only checks the result code; the body is not
+    parsed further. Raises CorosAPIError on an auth failure (e.g. result
+    "1019" = "Access token is invalid") or httpx.HTTPStatusError on 401/403.
+    Does NOT re-login or mutate the stored token, so the caller sees the
+    token's true server-side state.
+    """
+    if not auth.access_token:
+        raise CorosAPIError("no_token", "No web access token stored")
+    url = _base_url(auth.region) + ENDPOINTS["dashboard"]
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(url, headers=_auth_headers(auth))
+        resp.raise_for_status()
+        body = resp.json()
+    _check_response(body, "token verification")
+
+
 # ---------------------------------------------------------------------------
 # HRV data  (confirmed: /dashboard/query → data.summaryInfo.sleepHrvData)
 # ---------------------------------------------------------------------------

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -256,6 +256,13 @@ async def check_coros_auth() -> dict:
     """
     Check whether valid Coros access tokens are stored locally.
 
+    This is a LOCAL check only: ``authenticated: true`` means the stored token has
+    not passed its 24h TTL by the local clock — it does NOT confirm the token is
+    still accepted by Coros. A token can be revoked server-side (password change,
+    account lock) or invalidated early and still report authenticated here; the
+    next real data call would then fail with an auth error (which triggers a
+    re-login retry). ``expires_in_hours`` is likewise a local TTL estimate.
+
     Returns
     -------
     dict with keys: authenticated, user_id, region, expires_in_hours,

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -252,21 +252,32 @@ async def authenticate_coros_mobile(
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-async def check_coros_auth() -> dict:
+async def check_coros_auth(verify_with_server: bool = False) -> dict:
     """
     Check whether valid Coros access tokens are stored locally.
 
-    This is a LOCAL check only: ``authenticated: true`` means the stored token has
-    not passed its 24h TTL by the local clock — it does NOT confirm the token is
-    still accepted by Coros. A token can be revoked server-side (password change,
-    account lock) or invalidated early and still report authenticated here; the
-    next real data call would then fail with an auth error (which triggers a
+    By default this is a LOCAL check only: ``authenticated: true`` means the stored
+    token has not passed its 24h TTL by the local clock — it does NOT confirm the
+    token is still accepted by Coros. A token can be revoked server-side (password
+    change, account lock) or invalidated early and still report authenticated here;
+    the next real data call would then fail with an auth error (which triggers a
     re-login retry). ``expires_in_hours`` is likewise a local TTL estimate.
+
+    Parameters
+    ----------
+    verify_with_server : bool
+        When True, additionally make one lightweight read call to Coros to confirm
+        the web token is still accepted, adding a ``server_verified`` key:
+        ``True`` (accepted), ``False`` (rejected — revoked/expired/wrong region), or
+        ``None`` (inconclusive, e.g. a network error) with a ``server_message``.
+        This does not re-login or alter the stored token. Off by default to keep
+        the check cheap and offline.
 
     Returns
     -------
     dict with keys: authenticated, user_id, region, expires_in_hours,
-    mobile_authenticated, mobile_token_status
+    mobile_authenticated, mobile_token_status (plus server_verified/server_message
+    when verify_with_server is True)
     """
     auth = coros_api.get_stored_auth()
     if auth is None:
@@ -288,7 +299,7 @@ async def check_coros_auth() -> dict:
     else:
         mobile_status = "missing (run auth or auth-mobile)"
 
-    return {
+    result = {
         "authenticated": bool(auth.access_token),
         "user_id": auth.user_id,
         "region": auth.region,
@@ -296,6 +307,31 @@ async def check_coros_auth() -> dict:
         "mobile_authenticated": has_mobile,
         "mobile_token_status": mobile_status,
     }
+
+    if verify_with_server:
+        result.update(await _verify_web_token_status(auth))
+
+    return result
+
+
+async def _verify_web_token_status(auth: coros_api.StoredAuth) -> dict:
+    """Probe Coros to confirm the web token, mapping the outcome to result keys.
+
+    Never raises: a rejected token yields server_verified False, while a network
+    or decode failure yields None (inconclusive) — a transport error must not be
+    read as "token invalid". CorosAPIError is caught before httpx errors and
+    before the generic ValueError (of which it is a subclass)."""
+    try:
+        await coros_api.verify_web_token(auth)
+        return {"server_verified": True}
+    except coros_api.CorosAPIError as exc:
+        return {"server_verified": False, "server_message": str(exc)}
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            return {"server_verified": False, "server_message": f"HTTP {exc.response.status_code}"}
+        return {"server_verified": None, "server_message": f"inconclusive: HTTP {exc.response.status_code}"}
+    except (httpx.HTTPError, ValueError) as exc:
+        return {"server_verified": None, "server_message": f"inconclusive: {exc}"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_check_auth_verify.py
+++ b/tests/test_check_auth_verify.py
@@ -1,0 +1,82 @@
+"""Tests for check_coros_auth's optional server-side token verification (issue #49).
+
+Covers:
+  - default (verify_with_server=False) stays a local-only check, no probe
+  - verify_with_server=True maps accept / reject / inconclusive outcomes
+"""
+import asyncio
+
+import httpx
+import pytest
+
+from coros_mcp import coros_api
+from coros_mcp.server import check_coros_auth
+
+
+def _stored():
+    return coros_api.StoredAuth(
+        access_token="tok", user_id="u1", region="eu",
+        timestamp=0, mobile_access_token=None, mobile_login_payload=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_token(monkeypatch):
+    # Report the local token as fresh so the branch under test is reached.
+    monkeypatch.setattr(coros_api, "get_stored_auth", lambda: _stored())
+
+
+def test_default_does_not_probe_server(monkeypatch):
+    called = False
+
+    async def _boom(_auth):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(coros_api, "verify_web_token", _boom)
+    result = asyncio.run(check_coros_auth())
+    assert "server_verified" not in result
+    assert called is False
+
+
+def test_verify_accepted(monkeypatch):
+    async def _ok(_auth):
+        return None
+
+    monkeypatch.setattr(coros_api, "verify_web_token", _ok)
+    result = asyncio.run(check_coros_auth(verify_with_server=True))
+    assert result["server_verified"] is True
+
+
+def test_verify_rejected_on_auth_error(monkeypatch):
+    async def _rejected(_auth):
+        raise coros_api.CorosAPIError("1019", "Access token is invalid")
+
+    monkeypatch.setattr(coros_api, "verify_web_token", _rejected)
+    result = asyncio.run(check_coros_auth(verify_with_server=True))
+    assert result["server_verified"] is False
+    assert "invalid" in result["server_message"].lower()
+
+
+def test_verify_rejected_on_http_401(monkeypatch):
+    async def _401(_auth):
+        raise httpx.HTTPStatusError(
+            "unauthorized",
+            request=httpx.Request("GET", "https://x"),
+            response=httpx.Response(401),
+        )
+
+    monkeypatch.setattr(coros_api, "verify_web_token", _401)
+    result = asyncio.run(check_coros_auth(verify_with_server=True))
+    assert result["server_verified"] is False
+
+
+def test_verify_inconclusive_on_network_error(monkeypatch):
+    async def _netfail(_auth):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(coros_api, "verify_web_token", _netfail)
+    result = asyncio.run(check_coros_auth(verify_with_server=True))
+    # A transport failure must NOT be reported as an invalid token.
+    assert result["server_verified"] is None
+    assert "inconclusive" in result["server_message"]


### PR DESCRIPTION
Addresses three open issues. `ruff` clean; full suite **189 passed**.

## #47 — mobile login `region` string (not a bug) — *docs*
The `310|Europe/Berlin|US` value was captured via mitmproxy from a **working EU-account login** (commit 2916fa9). It is device SIM/locale telemetry — `<MCC>|<device timezone>|<locale>`, where `310` is the US SIM MCC of the capture emulator — **not** the Coros account region. Regional routing is by base URL (`apieu`/`apius`), already correct. An EU account already sends MCC `310` and receives EU data, so Coros does not validate this field against the account. Added a comment to prevent an incorrect "fix" later. **Issue closed as not-a-bug.**

## #48 — hardcoded device fingerprint — *docs, deferred*
Documented the fingerprint's origin and the manual refresh process for when a stale client is blocked. Env-var configurability deferred (labeled `future enhancement`) until there's evidence Coros enforces it.

## #49 — server-side token verification — *implemented (opt-in)*
`check_coros_auth` gains an opt-in `verify_with_server: bool = False`. Default preserves the cheap local-only check (no behavior change). When True it makes one lightweight dashboard GET (cheapest authenticated read) and returns:
- `server_verified: True` — token accepted
- `server_verified: False` — rejected (revoked / expired / wrong region) + `server_message`
- `server_verified: None` — inconclusive (e.g. network error) + `server_message`

Safe by construction: read-only; called directly (not via `_run_with_auth`) so it never re-logs-in or mutates the stored token; a transport error is reported as inconclusive rather than "invalid". New tests cover accept / reject (CorosAPIError + HTTP 401) / inconclusive, plus that the default path does not probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)