### PR TITLE
Add duration_meters: genuine distance-triggered workout steps

### DIFF
--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -856,6 +856,11 @@ def _build_workout_program_payload(
         """
         low = s.get("intensity_low", s.get("power_low_w", 0))
         high = s.get("intensity_high", s.get("power_high_w", 0))
+        if "duration_meters" in s and "duration_minutes" in s:
+            raise ValueError(
+                f"step {s.get('name', '<unnamed>')!r} must set either "
+                "duration_minutes or duration_meters, not both"
+            )
         if "duration_meters" in s:
             return {
                 "targetType": 5,

--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -836,6 +836,50 @@ def _build_workout_program_payload(
     total_seconds = 0
     ex_id = 0  # sequential exercise IDs (API uses these to link groups)
 
+    def _target_fields(s: dict) -> dict:
+        """Return the targetType/targetValue/intensityMultiplier fields for a
+        step, plus its intensity values scaled to match.
+
+        Two mutually exclusive duration keys are supported:
+          - duration_minutes: time-based (targetType=2, seconds, intensity
+            values used as-is).
+          - duration_meters: distance-based (targetType=5, meters x100 -- the
+            same convention every other distance field in this API uses --
+            intensityMultiplier=1000 with intensity values scaled x1000).
+
+        The x1000 intensity scaling for distance steps and targetType=5 are
+        not documented anywhere in Coros's API; confirmed by building a
+        distance-type step in the Coros app itself and reading back the raw
+        values via /training/schedule/query. targetType=1 (a natural first
+        guess) is NOT distance -- it silently produces a zero-duration,
+        zero-distance step with no error.
+        """
+        low = s.get("intensity_low", s.get("power_low_w", 0))
+        high = s.get("intensity_high", s.get("power_high_w", 0))
+        if "duration_meters" in s:
+            return {
+                "targetType": 5,
+                "targetValue": int(s["duration_meters"] * 100),
+                "intensityValue": int(low * 1000),
+                "intensityValueExtend": int(high * 1000),
+                "intensityMultiplier": 1000,
+                "seconds": 0,  # real elapsed time is unknown ahead of time
+            }
+        if "duration_minutes" not in s:
+            raise ValueError(
+                f"step {s.get('name', '<unnamed>')!r} needs duration_minutes "
+                "or duration_meters"
+            )
+        duration_s = int(s["duration_minutes"] * 60)
+        return {
+            "targetType": 2,
+            "targetValue": duration_s,
+            "intensityValue": low,
+            "intensityValueExtend": high,
+            "intensityMultiplier": 0,
+            "seconds": duration_s,
+        }
+
     # Workout API uses a single Running wire ID (sportType=1); the activity
     # API splits runs into 100 (Running), 102 (Trail), 103 (Track). Accept
     # the activity-side IDs (what list_activities returns) and map them onto
@@ -869,9 +913,8 @@ def _build_workout_program_payload(
             group_id = ex_id
 
             sub_steps = step["steps"]
-            iteration_seconds = sum(
-                int(s["duration_minutes"] * 60) for s in sub_steps
-            )
+            sub_fields = [_target_fields(s) for s in sub_steps]
+            iteration_seconds = sum(f["seconds"] for f in sub_fields)
             total_seconds += iteration_seconds * step["repeat"]
 
             exercises.append({
@@ -892,19 +935,19 @@ def _build_workout_program_payload(
                 "originId": "0",
             })
 
-            for j, sub in enumerate(sub_steps):
+            for j, (sub, fields) in enumerate(zip(sub_steps, sub_fields, strict=True)):
                 ex_id += 1
-                sub_duration = int(sub["duration_minutes"] * 60)
                 exercises.append({
                     "id": ex_id,
                     "name": sub["name"],
                     "exerciseType": 2,
                     "sportType": wire_sport_type,
                     "intensityType": intensity_type,
-                    "intensityValue": sub.get("intensity_low", sub.get("power_low_w", 0)),
-                    "intensityValueExtend": sub.get("intensity_high", sub.get("power_high_w", 0)),
-                    "targetType": 2,
-                    "targetValue": sub_duration,
+                    "intensityValue": fields["intensityValue"],
+                    "intensityValueExtend": fields["intensityValueExtend"],
+                    "intensityMultiplier": fields["intensityMultiplier"],
+                    "targetType": fields["targetType"],
+                    "targetValue": fields["targetValue"],
                     "sets": 1,
                     "sortNo": group_sort + 65536 * (j + 1),
                     "restType": 3,
@@ -917,18 +960,19 @@ def _build_workout_program_payload(
             # --- Plain step ---
             top_index += 1
             ex_id += 1
-            duration_s = int(step["duration_minutes"] * 60)
-            total_seconds += duration_s
+            fields = _target_fields(step)
+            total_seconds += fields["seconds"]
             exercises.append({
                 "id": ex_id,
                 "name": step["name"],
                 "exerciseType": 2,
                 "sportType": wire_sport_type,
                 "intensityType": intensity_type,
-                "intensityValue": step.get("intensity_low", step.get("power_low_w", 0)),
-                "intensityValueExtend": step.get("intensity_high", step.get("power_high_w", 0)),
-                "targetType": 2,
-                "targetValue": duration_s,
+                "intensityValue": fields["intensityValue"],
+                "intensityValueExtend": fields["intensityValueExtend"],
+                "intensityMultiplier": fields["intensityMultiplier"],
+                "targetType": fields["targetType"],
+                "targetValue": fields["targetValue"],
                 "sets": 1,
                 "sortNo": 16777216 * top_index,
                 "restType": 3,

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -107,16 +107,22 @@ def _attach_enrichment_warning(result: dict, response: dict) -> dict:
 
 
 def _summarize_steps(steps: list[dict]) -> tuple[float, int]:
-    """Return (total_minutes, steps_count) for a workout step list."""
+    """Return (total_minutes, steps_count) for a workout step list.
+
+    total_minutes only counts duration_minutes steps -- a duration_meters
+    step's real elapsed time isn't known ahead of time, so it contributes 0
+    to the total rather than a guess. Check steps_count against len(steps)
+    if a workout mixes both kinds and the total looks low.
+    """
     total_minutes = 0.0
     steps_count = 0
     for s in steps:
         if "repeat" in s:
-            sub_mins = sum(sub["duration_minutes"] for sub in s["steps"])
+            sub_mins = sum(sub.get("duration_minutes", 0) for sub in s["steps"])
             total_minutes += sub_mins * s["repeat"]
             steps_count += 1 + len(s["steps"])
         else:
-            total_minutes += s["duration_minutes"]
+            total_minutes += s.get("duration_minutes", 0)
             steps_count += 1
     return total_minutes, steps_count
 
@@ -744,7 +750,13 @@ async def save_workout_template(
 
         Plain step:
         - name (str): step label, e.g. "10:00 Warm-up"
-        - duration_minutes (float): step duration in minutes
+        - duration_minutes (float) OR duration_meters (float): step length,
+          time-based or distance-based. Use duration_meters for a step that
+          should end at a real distance regardless of pace (e.g. "1000" for
+          a 1km rep) rather than an estimated time -- a duration_minutes
+          step ends after that much elapsed time even if actual pace made it
+          cover more or less than the intended distance. Exactly one of the
+          two is required.
         - intensity_low (int): lower intensity target (watts, BPM, etc. depending on intensity_type)
         - intensity_high (int): upper intensity target (0 = open-ended)
         Note: power_low_w / power_high_w are accepted as legacy aliases for intensity_low / intensity_high.
@@ -762,6 +774,10 @@ async def save_workout_template(
             ]},
             {"name": "Cool-down", "duration_minutes": 10, "intensity_low": 100, "intensity_high": 165},
         ]
+
+        Distance-based rep (intensity_low/high in pace seconds/km when
+        intensity_type=3), ends at a real 1000m regardless of actual pace:
+        {"name": "1km @ 4:00/km", "duration_meters": 1000, "intensity_low": 235, "intensity_high": 245}
 
     sport_type : int
         Sport type ID, in the ACTIVITY namespace (the same IDs list_activities

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -106,25 +106,68 @@ def _attach_enrichment_warning(result: dict, response: dict) -> dict:
     return result
 
 
-def _summarize_steps(steps: list[dict]) -> tuple[float, int]:
-    """Return (total_minutes, steps_count) for a workout step list.
+def _summarize_steps(steps: list[dict]) -> tuple[float, float, int]:
+    """Return (total_minutes, distance_meters_total, steps_count) for a
+    workout step list.
 
-    total_minutes only counts duration_minutes steps -- a duration_meters
-    step's real elapsed time isn't known ahead of time, so it contributes 0
-    to the total rather than a guess. Check steps_count against len(steps)
-    if a workout mixes both kinds and the total looks low.
+    total_minutes only counts duration_minutes steps, and
+    distance_meters_total only counts duration_meters steps -- a step's
+    real elapsed time/distance isn't knowable from the other unit ahead of
+    time, so each contributes 0 to the total it doesn't measure rather than
+    a guess. Check steps_count against len(steps), or see the mixed-duration
+    warning attached by _attach_mixed_duration_warning, if a workout mixes
+    both kinds and either total looks low.
     """
     total_minutes = 0.0
+    distance_meters_total = 0.0
     steps_count = 0
     for s in steps:
         if "repeat" in s:
             sub_mins = sum(sub.get("duration_minutes", 0) for sub in s["steps"])
+            sub_meters = sum(sub.get("duration_meters", 0) for sub in s["steps"])
             total_minutes += sub_mins * s["repeat"]
+            distance_meters_total += sub_meters * s["repeat"]
             steps_count += 1 + len(s["steps"])
         else:
             total_minutes += s.get("duration_minutes", 0)
+            distance_meters_total += s.get("duration_meters", 0)
             steps_count += 1
-    return total_minutes, steps_count
+    return total_minutes, distance_meters_total, steps_count
+
+
+_MIXED_DURATION_WARNING = (
+    "This workout mixes time-based and distance-based steps. total_minutes "
+    "only covers the time-based steps and distance_meters_total only covers "
+    "the distance-based ones -- neither total represents the whole workout's "
+    "length by itself."
+)
+
+
+def _has_mixed_durations(steps: list[dict]) -> bool:
+    """True if steps (including inside repeat groups) mix duration_minutes
+    and duration_meters step types."""
+    has_minutes = False
+    has_meters = False
+    for s in steps:
+        candidates = s["steps"] if "repeat" in s else [s]
+        for c in candidates:
+            if "duration_minutes" in c:
+                has_minutes = True
+            if "duration_meters" in c:
+                has_meters = True
+    return has_minutes and has_meters
+
+
+def _attach_mixed_duration_warning(result: dict, steps: list[dict]) -> dict:
+    """Add (or append to) a top-level `warning` if steps mix time- and
+    distance-based durations, so total_minutes/distance_meters_total aren't
+    misread as covering the whole workout's length."""
+    if _has_mixed_durations(steps):
+        if "warning" in result:
+            result["warning"] = result["warning"] + " " + _MIXED_DURATION_WARNING
+        else:
+            result["warning"] = _MIXED_DURATION_WARNING
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -795,7 +838,9 @@ async def save_workout_template(
 
     Returns
     -------
-    dict with keys: workout_id, name, total_minutes, steps_count, message
+    dict with keys: workout_id, name, total_minutes, distance_meters_total,
+    steps_count, message, and optionally 'warning' if the workout mixes
+    time-based and distance-based steps (see _summarize_steps)
     """
     auth = await _get_auth()
     if auth is None:
@@ -805,14 +850,16 @@ async def save_workout_template(
             coros_api.save_workout_template, auth, name, steps, sport_type, intensity_type,
             retry_all=False,
         )
-        total_minutes, steps_count = _summarize_steps(steps)
-        return {
+        total_minutes, distance_meters_total, steps_count = _summarize_steps(steps)
+        result = {
             "workout_id": workout_id,
             "name": name,
             "total_minutes": total_minutes,
+            "distance_meters_total": distance_meters_total,
             "steps_count": steps_count,
             "message": "Workout created. Open Coros app → Workouts to sync to watch.",
         }
+        return _attach_mixed_duration_warning(result, steps)
     except Exception as exc:
         return {"error": str(exc)}
 
@@ -1057,8 +1104,10 @@ async def schedule_workout(
 
     Returns
     -------
-    dict with keys: scheduled, name, happen_day, total_minutes, steps_count,
-    response, and optionally 'warning' if enrichment lookup failed.
+    dict with keys: scheduled, name, happen_day, total_minutes,
+    distance_meters_total, steps_count, response, and optionally 'warning'
+    if enrichment lookup failed and/or the workout mixes time-based and
+    distance-based steps (warnings are concatenated if both apply).
 
     The 'response' dict contains the server-assigned identifiers needed to
     later remove this calendar entry: plan_id, id_in_plan, plan_program_id,
@@ -1083,18 +1132,20 @@ async def schedule_workout(
             sort_no,
             retry_all=False,
         )
-        total_minutes, steps_count = _summarize_steps(steps)
-        return _attach_enrichment_warning(
+        total_minutes, distance_meters_total, steps_count = _summarize_steps(steps)
+        result = _attach_enrichment_warning(
             {
                 "scheduled": True,
                 "name": name,
                 "happen_day": happen_day,
                 "total_minutes": total_minutes,
+                "distance_meters_total": distance_meters_total,
                 "steps_count": steps_count,
                 "response": response,
             },
             response,
         )
+        return _attach_mixed_duration_warning(result, steps)
     except Exception as exc:
         return {"error": str(exc), "scheduled": False}
 

--- a/tests/test_duration_meters_summary.py
+++ b/tests/test_duration_meters_summary.py
@@ -1,0 +1,152 @@
+"""Tests for distance-based step support in _summarize_steps and the new
+mixed-duration warning (review feedback on PR #52).
+
+Covers:
+  1. _summarize_steps: time-only steps (existing behavior preserved)
+  2. _summarize_steps: distance-only steps, including repeat groups
+  3. _summarize_steps: steps_count unaffected by the new return value
+  4. _has_mixed_durations: pure time / pure distance / actually mixed
+  5. _attach_mixed_duration_warning: adds, no-ops, and appends-not-overwrites
+"""
+
+from coros_mcp.server import (
+    _MIXED_DURATION_WARNING,
+    _attach_mixed_duration_warning,
+    _has_mixed_durations,
+    _summarize_steps,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Time-only steps - existing behavior preserved
+# ---------------------------------------------------------------------------
+
+
+def test_time_only_steps():
+    steps = [
+        {"name": "Warmup", "duration_minutes": 10},
+        {"name": "Main", "duration_minutes": 30},
+    ]
+    total_minutes, distance_meters_total, steps_count = _summarize_steps(steps)
+    assert total_minutes == 40
+    assert distance_meters_total == 0
+    assert steps_count == 2
+
+
+def test_time_only_repeat_group():
+    steps = [
+        {
+            "repeat": 4,
+            "steps": [
+                {"name": "On", "duration_minutes": 5},
+                {"name": "Off", "duration_minutes": 2},
+            ],
+        }
+    ]
+    total_minutes, distance_meters_total, steps_count = _summarize_steps(steps)
+    assert total_minutes == 28  # (5 + 2) * 4
+    assert distance_meters_total == 0
+    assert steps_count == 3  # 1 header + 2 subs, not multiplied by repeat
+
+
+# ---------------------------------------------------------------------------
+# 2. Distance-only steps
+# ---------------------------------------------------------------------------
+
+
+def test_distance_only_steps():
+    steps = [
+        {"name": "Warmup", "duration_meters": 1000},
+        {"name": "Main", "duration_meters": 5000},
+    ]
+    total_minutes, distance_meters_total, steps_count = _summarize_steps(steps)
+    assert total_minutes == 0
+    assert distance_meters_total == 6000
+    assert steps_count == 2
+
+
+def test_distance_repeat_group_applies_multiplier():
+    steps = [
+        {
+            "repeat": 3,
+            "steps": [
+                {"name": "On", "duration_meters": 400},
+                {"name": "Off", "duration_meters": 200},
+            ],
+        }
+    ]
+    total_minutes, distance_meters_total, steps_count = _summarize_steps(steps)
+    assert total_minutes == 0
+    assert distance_meters_total == 1800  # (400 + 200) * 3
+    assert steps_count == 3
+
+
+# ---------------------------------------------------------------------------
+# 3. Mixed time + distance
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_steps_both_totals_populated():
+    steps = [
+        {"name": "Warmup", "duration_minutes": 10},
+        {"name": "Interval", "duration_meters": 1000},
+    ]
+    total_minutes, distance_meters_total, steps_count = _summarize_steps(steps)
+    assert total_minutes == 10
+    assert distance_meters_total == 1000
+    assert steps_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. _has_mixed_durations
+# ---------------------------------------------------------------------------
+
+
+def test_has_mixed_durations_false_when_time_only():
+    steps = [{"duration_minutes": 10}, {"duration_minutes": 5}]
+    assert _has_mixed_durations(steps) is False
+
+
+def test_has_mixed_durations_false_when_distance_only():
+    steps = [{"duration_meters": 1000}, {"duration_meters": 2000}]
+    assert _has_mixed_durations(steps) is False
+
+
+def test_has_mixed_durations_true_when_mixed():
+    steps = [{"duration_minutes": 10}, {"duration_meters": 1000}]
+    assert _has_mixed_durations(steps) is True
+
+
+def test_has_mixed_durations_checks_inside_repeat_groups():
+    steps = [
+        {
+            "repeat": 2,
+            "steps": [
+                {"duration_minutes": 5},
+                {"duration_meters": 400},
+            ],
+        }
+    ]
+    assert _has_mixed_durations(steps) is True
+
+
+# ---------------------------------------------------------------------------
+# 5. _attach_mixed_duration_warning
+# ---------------------------------------------------------------------------
+
+
+def test_attach_mixed_duration_warning_adds_when_mixed():
+    steps = [{"duration_minutes": 10}, {"duration_meters": 1000}]
+    result = _attach_mixed_duration_warning({"scheduled": True}, steps)
+    assert result["warning"] == _MIXED_DURATION_WARNING
+
+
+def test_attach_mixed_duration_warning_noop_when_not_mixed():
+    steps = [{"duration_minutes": 10}, {"duration_minutes": 5}]
+    result = _attach_mixed_duration_warning({"scheduled": True}, steps)
+    assert "warning" not in result
+
+
+def test_attach_mixed_duration_warning_appends_not_overwrites():
+    steps = [{"duration_minutes": 10}, {"duration_meters": 1000}]
+    result = _attach_mixed_duration_warning({"scheduled": True, "warning": "enrichment failed"}, steps)
+    assert result["warning"] == "enrichment failed " + _MIXED_DURATION_WARNING

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -317,6 +317,86 @@ def test_cycling_empty_steps_raises():
         _build_workout_program_payload(name="empty", steps=[])
 
 
+def test_distance_step_target_type_and_value():
+    """duration_meters emits targetType=5, targetValue in meters x100, and
+    scales intensity by x1000 with intensityMultiplier=1000 -- confirmed
+    against a real distance-type step built in the Coros app and read back
+    via the API, not documented anywhere in Coros's own API."""
+    payload = _build_workout_program_payload(
+        name="1km rep",
+        steps=[
+            {"name": "1km @ 4:00/km", "duration_meters": 1000, "intensity_low": 235, "intensity_high": 245},
+        ],
+    )
+    ex = payload["exercises"][0]
+    assert ex["targetType"] == 5
+    assert ex["targetValue"] == 100000  # 1000m x 100
+    assert ex["intensityValue"] == 235000  # 235 sec/km x 1000
+    assert ex["intensityValueExtend"] == 245000
+    assert ex["intensityMultiplier"] == 1000
+
+
+def test_time_step_intensity_multiplier_is_zero():
+    """Time-based steps get an explicit intensityMultiplier=0 (matching what
+    the server echoes back for them), not just an absent key."""
+    payload = _build_workout_program_payload(
+        name="tempo",
+        steps=[
+            {"name": "Tempo", "duration_minutes": 20, "intensity_low": 240, "intensity_high": 250},
+        ],
+    )
+    ex = payload["exercises"][0]
+    assert ex["targetType"] == 2
+    assert ex["intensityMultiplier"] == 0
+    assert ex["intensityValue"] == 240  # unscaled
+
+
+def test_distance_step_does_not_contribute_to_estimated_time():
+    """A distance step's real elapsed time isn't known ahead of time, so it
+    contributes 0 rather than a guess -- estimatedTime only reflects the
+    time-based steps in a mixed workout."""
+    payload = _build_workout_program_payload(
+        name="mixed",
+        steps=[
+            {"name": "Warmup", "duration_minutes": 10, "intensity_low": 300, "intensity_high": 360},
+            {"name": "22km @ open pace", "duration_meters": 22000, "intensity_low": 240, "intensity_high": 480},
+        ],
+    )
+    assert payload["estimatedTime"] == 10 * 60
+
+
+def test_distance_step_in_repeat_group():
+    """duration_meters works inside a repeat group's sub-steps too, and is
+    excluded from the group header's own time-based targetValue."""
+    payload = _build_workout_program_payload(
+        name="6x1km",
+        steps=[
+            {"repeat": 6, "steps": [
+                {"name": "1km", "duration_meters": 1000, "intensity_low": 235, "intensity_high": 245},
+                {"name": "Recovery", "duration_minutes": 2, "intensity_low": 330, "intensity_high": 480},
+            ]},
+        ],
+    )
+    header, rep, recovery = payload["exercises"][0], payload["exercises"][1], payload["exercises"][2]
+    # group header's targetValue is one iteration's seconds (distance sub-step
+    # contributes 0): 0 + 120 = 120. The x6 repeat is a separate `sets` field,
+    # not baked into this value.
+    assert header["targetValue"] == 120
+    assert header["sets"] == 6
+    assert rep["targetType"] == 5
+    assert rep["targetValue"] == 100000
+    assert recovery["targetType"] == 2
+    assert recovery["targetValue"] == 120
+
+
+def test_step_missing_both_duration_keys_raises():
+    with pytest.raises(ValueError, match="duration_minutes or duration_meters"):
+        _build_workout_program_payload(
+            name="broken",
+            steps=[{"name": "???", "intensity_low": 100, "intensity_high": 150}],
+        )
+
+
 def test_cycling_sport_and_intensity_types_propagate():
     payload = _build_workout_program_payload(
         name="hr",

--- a/tests/test_workout_payloads.py
+++ b/tests/test_workout_payloads.py
@@ -397,6 +397,23 @@ def test_step_missing_both_duration_keys_raises():
         )
 
 
+def test_step_with_both_duration_keys_raises():
+    """duration_minutes and duration_meters are mutually exclusive; a step
+    carrying both would be built as a distance step but counted in both
+    summary totals, so reject it outright."""
+    with pytest.raises(ValueError, match="not both"):
+        _build_workout_program_payload(
+            name="broken",
+            steps=[{
+                "name": "???",
+                "duration_minutes": 4,
+                "duration_meters": 1000,
+                "intensity_low": 235,
+                "intensity_high": 245,
+            }],
+        )
+
+
 def test_cycling_sport_and_intensity_types_propagate():
     payload = _build_workout_program_payload(
         name="hr",


### PR DESCRIPTION
## Problem

`schedule_workout`/`save_workout_template` only ever build time-based steps -- `targetType` is hardcoded to `2` (time, seconds) for every cardio step, with no distance option. A "1km @ 4:00/km" rep is actually built as "4 minutes," which only reads as a clean 1km if the athlete's real pace happens to match the assumed pace exactly. For anything where the real trigger needs to be a distance (e.g. "run 22km, then switch to marathon pace"), a time estimate drifts off the real distance depending on actual pace.

## Fix

Adds `duration_meters` as an alternative to `duration_minutes` for both plain steps and repeat-group sub-steps. When present, the step is built as a genuine distance target instead of a time estimate.

The distance-step encoding (`targetType: 5`, `intensityMultiplier: 1000` with intensity values scaled x1000) isn't documented anywhere in Coros's API. I found it by building a distance-type step manually in the Coros app and reading back the raw values via `/training/schedule/query` -- a first guess of `targetType: 1` failed silently (`calculate_workout_program` returned an all-zero result, no error).

## Testing

- 5 new unit tests covering the distance-step payload shape, the unaffected time-step path, mixed time/distance workouts, repeat groups, and the missing-duration error case. All existing tests still pass (194 total).
- ruff and mypy clean.
- Verified against the live Coros API: scheduled a real two-step test workout (1km distance rep + 2min recovery) via `schedule_workout`, confirmed the stored raw values matched exactly (`targetType: 5`/`targetValue: 100000` for the distance step, correct intensity scaling), then removed it.
