### PR TITLE
feat: toolset gating, strict schemas, and MCP annotations for agent use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,5 +62,8 @@ All source modules live in the `coros_mcp/` package:
 ### API Response Pattern
 All Coros API responses return `result: "0000"` on success. Any other value indicates an error — check `message` field. Large time-series fields (`graphList`, `frequencyList`, `gpsLightDuration`) are stripped from activity detail responses to keep them manageable.
 
+### Toolset Gating (agent hardening)
+`COROS_MCP_TOOLSET=readonly` registers only the 12 read tools (hides write tools, raw escape hatches, and auth tools); `COROS_MCP_HIDE_AUTH_TOOLS=1` hides just the `authenticate_*` tools. Both are evaluated at import time in `server.py` via the `_tool()` registration wrapper; excluded functions remain plain callables (tests import them directly). `get_help` filters its listing against the registered set. Date/range parameters are schema-validated (`_Day` pattern, `_Weeks` bounds) at the MCP layer.
+
 ### Region Handling
 Regions (`eu`, `us`) map to different base URLs for both APIs. EU tokens only work on EU endpoints — mixing regions causes auth failures.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,35 @@ coros-mcp auth-status   # Check if authenticated
 coros-mcp auth-clear    # Remove stored tokens
 ```
 
+#### Step 4 (optional): Restrict the toolset for autonomous agents
+
+When the MCP client is an autonomous agent or a smaller open-weight model
+(e.g. [hermes-agent](https://github.com/NousResearch/hermes-agent) with a
+DeepSeek/Hermes model), two env vars harden the server:
+
+```
+COROS_MCP_TOOLSET=readonly       # expose only the 12 read tools
+COROS_MCP_HIDE_AUTH_TOOLS=1      # hide authenticate_* (credentials never enter the model context)
+```
+
+- `COROS_MCP_TOOLSET=readonly` hides everything that writes to your Coros
+  account (save/schedule/update/delete tools) plus the low-level raw escape
+  hatches, leaving: `get_help`, `check_coros_auth`, `get_daily_metrics`,
+  `get_sleep_data`, `list_activities`, `get_activity_detail`,
+  `list_workout_templates`, `list_training_plans`, `list_planned_activities`,
+  `list_exercises`, `sync_coros_data`, `get_cache_status`. A smaller tool
+  list also improves tool-calling reliability of non-frontier models.
+  Default: `full` (all 26 tools).
+- `COROS_MCP_HIDE_AUTH_TOOLS=1` removes the two `authenticate_*` tools so
+  your password can never travel through the model context or agent logs.
+  Authentication then happens exclusively via the `COROS_EMAIL` /
+  `COROS_PASSWORD` env auto-login (or tokens stored beforehand with
+  `coros-mcp auth`).
+
+All tools additionally carry MCP `readOnlyHint` / `destructiveHint`
+annotations, so agent harnesses that honor them can require confirmation
+for write actions.
+
 ---
 
 ## Tool Reference

--- a/coros_mcp/server.py
+++ b/coros_mcp/server.py
@@ -18,12 +18,15 @@ transparently whenever the stored token is expired or rejected.
 """
 
 import json
+import os
 import time
 from datetime import datetime, timedelta
+from typing import Annotated, Literal
 
 import httpx
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from pydantic import Field
 
 from coros_mcp import coros_api
 from coros_mcp.cache.store import cache_status, init_db
@@ -42,6 +45,69 @@ load_dotenv()
 init_db()
 
 mcp = FastMCP("coros-mcp")
+
+# ---------------------------------------------------------------------------
+# Toolset gating
+#
+# COROS_MCP_TOOLSET=readonly exposes only the compact read surface (metrics,
+# sleep, activities, plans, cache) and hides everything that writes to the
+# Coros account plus the low-level raw/update escape hatches — recommended
+# when the MCP client is an autonomous agent or a smaller model that handles
+# a large tool list poorly. Default: full (all tools, backward compatible).
+#
+# COROS_MCP_HIDE_AUTH_TOOLS=1 additionally hides authenticate_coros /
+# authenticate_coros_mobile so account credentials never travel through the
+# model context; authentication then happens exclusively via the
+# COROS_EMAIL / COROS_PASSWORD env auto-login.
+# ---------------------------------------------------------------------------
+
+_TOOLSET = os.environ.get("COROS_MCP_TOOLSET", "full").strip().lower()
+if _TOOLSET not in ("full", "readonly"):
+    raise ValueError(
+        f"COROS_MCP_TOOLSET must be 'full' or 'readonly', got {_TOOLSET!r}"
+    )
+_HIDE_AUTH_TOOLS = (
+    os.environ.get("COROS_MCP_HIDE_AUTH_TOOLS", "").strip().lower()
+    in ("1", "true", "yes")
+)
+
+# Names of the functions actually registered as MCP tools (get_help filters
+# its listing against this so hidden tools are never advertised).
+_ENABLED_TOOLS: set[str] = set()
+
+# MCP ToolAnnotations presets (hints for the client's permission handling).
+_READ = {"readOnlyHint": True, "openWorldHint": True}
+_READ_LOCAL = {"readOnlyHint": True, "openWorldHint": False}
+_WRITE = {"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True}
+_DESTRUCTIVE = {"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True}
+
+
+def _tool(*, write: bool = False, advanced: bool = False, auth_tool: bool = False,
+          annotations: dict | None = None):
+    """Register a function as an MCP tool unless the toolset excludes it.
+
+    write: modifies the Coros account server-side.
+    advanced: raw/low-level escape hatch only useful in write workflows.
+    auth_tool: takes account credentials as parameters.
+
+    Excluded functions stay plain importable/callable Python functions —
+    they are just not exposed over MCP.
+    """
+    def deco(fn):
+        if _TOOLSET == "readonly" and (write or advanced or auth_tool):
+            return fn
+        if _HIDE_AUTH_TOOLS and auth_tool:
+            return fn
+        _ENABLED_TOOLS.add(fn.__name__)
+        return mcp.tool(annotations=annotations)(fn)
+    return deco
+
+
+# YYYYMMDD parameter types — the pattern lands in the JSON schema, so
+# malformed dates are rejected by the MCP layer before any API call.
+_Day = Annotated[str, Field(pattern=r"^\d{8}$")]
+_DayOrEmpty = Annotated[str, Field(pattern=r"^(\d{8})?$")]
+_Weeks = Annotated[int, Field(ge=1, le=52)]
 
 _NOT_AUTHENTICATED = "Not authenticated. Set COROS_EMAIL and COROS_PASSWORD in .env or call authenticate_coros."  # noqa: E501
 
@@ -125,38 +191,42 @@ def _summarize_steps(steps: list[dict]) -> tuple[float, int]:
 # Tool: get_help
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+_TOOL_DESCRIPTIONS = [
+    {"name": "get_help", "description": "List all available tools (this tool)"},
+    {"name": "authenticate_coros", "description": "Log in with email/password; stores web API token (required before all data tools)"},  # noqa: E501
+    {"name": "authenticate_coros_mobile", "description": "Add mobile token for sleep stage data (deep/light/REM/awake)"},  # noqa: E501
+    {"name": "check_coros_auth", "description": "Show current auth status, region, and token expiry"},
+    {"name": "get_daily_metrics", "description": "Fetch daily training metrics: HRV, sleep hours, steps, stress, resting HR, VO2max, fitness score"},  # noqa: E501
+    {"name": "get_sleep_data", "description": "Fetch nightly sleep records with duration and quality score (mobile auth required for stage breakdown)"},  # noqa: E501
+    {"name": "list_activities", "description": "List recorded activities (runs, rides, swims, etc.) with summaries"},  # noqa: E501
+    {"name": "get_activity_detail", "description": "Get full detail for one activity by label_id"},
+    {"name": "list_workout_templates", "description": "List reusable workout templates saved in the Coros library"},  # noqa: E501
+    {"name": "list_training_plans", "description": "List training plans saved in the Coros Training Hub"},  # noqa: E501
+    {"name": "list_training_plans_raw", "description": "List raw training plans including entities and programs"},  # noqa: E501
+    {"name": "save_workout_template", "description": "Save a reusable cycling/intervals/running workout template to the library"},  # noqa: E501
+    {"name": "save_strength_workout_template", "description": "Save a reusable strength workout template to the library"},  # noqa: E501
+    {"name": "delete_workout_template", "description": "Delete a saved workout template by workout_id"},
+    {"name": "list_planned_activities", "description": "List workouts scheduled on the training calendar"},
+    {"name": "list_planned_activities_raw", "description": "List raw scheduled workouts for calendar update workflows"},  # noqa: E501
+    {"name": "calculate_workout_program", "description": "Recalculate edited workout program metrics before updating"},  # noqa: E501
+    {"name": "schedule_workout", "description": "Schedule a one-off cycling/intervals/running workout for a date (no library entry)"},  # noqa: E501
+    {"name": "add_planned_workout", "description": "Add an inline planned workout to the training calendar from raw objects"},  # noqa: E501
+    {"name": "update_scheduled_workout", "description": "Update an existing scheduled workout on the calendar"},  # noqa: E501
+    {"name": "schedule_strength_workout", "description": "Schedule a one-off strength workout for a date (no library entry)"},  # noqa: E501
+    {"name": "schedule_workout_template", "description": "Schedule an existing library workout template on a specific date"},  # noqa: E501
+    {"name": "remove_scheduled_workout", "description": "Remove a workout from the training calendar"},
+    {"name": "list_exercises", "description": "List available strength exercises (used when building strength workouts)"},  # noqa: E501
+    {"name": "sync_coros_data", "description": "Backfill local cache from the Coros API for a date range"},
+    {"name": "get_cache_status", "description": "Show local cache coverage: date ranges stored for each data type"},  # noqa: E501
+]
+
+
+@_tool(annotations=_READ_LOCAL)
 async def get_help() -> dict:
     """List all available Coros MCP tools with a short description of each."""
     return {
-        "tools": [
-            {"name": "get_help", "description": "List all available tools (this tool)"},
-            {"name": "authenticate_coros", "description": "Log in with email/password; stores web API token (required before all data tools)"},  # noqa: E501
-            {"name": "authenticate_coros_mobile", "description": "Add mobile token for sleep stage data (deep/light/REM/awake)"},  # noqa: E501
-            {"name": "check_coros_auth", "description": "Show current auth status, region, and token expiry"},
-            {"name": "get_daily_metrics", "description": "Fetch daily training metrics: HRV, sleep hours, steps, stress, resting HR, VO2max, fitness score"},  # noqa: E501
-            {"name": "get_sleep_data", "description": "Fetch nightly sleep records with duration and quality score (mobile auth required for stage breakdown)"},  # noqa: E501
-            {"name": "list_activities", "description": "List recorded activities (runs, rides, swims, etc.) with summaries"},  # noqa: E501
-            {"name": "get_activity_detail", "description": "Get full detail for one activity by label_id"},
-            {"name": "list_workout_templates", "description": "List reusable workout templates saved in the Coros library"},  # noqa: E501
-            {"name": "list_training_plans", "description": "List training plans saved in the Coros Training Hub"},  # noqa: E501
-            {"name": "list_training_plans_raw", "description": "List raw training plans including entities and programs"},  # noqa: E501
-            {"name": "save_workout_template", "description": "Save a reusable cycling/intervals/running workout template to the library"},  # noqa: E501
-            {"name": "save_strength_workout_template", "description": "Save a reusable strength workout template to the library"},  # noqa: E501
-            {"name": "delete_workout_template", "description": "Delete a saved workout template by workout_id"},
-            {"name": "list_planned_activities", "description": "List workouts scheduled on the training calendar"},
-            {"name": "list_planned_activities_raw", "description": "List raw scheduled workouts for calendar update workflows"},  # noqa: E501
-            {"name": "calculate_workout_program", "description": "Recalculate edited workout program metrics before updating"},  # noqa: E501
-            {"name": "schedule_workout", "description": "Schedule a one-off cycling/intervals/running workout for a date (no library entry)"},  # noqa: E501
-            {"name": "add_planned_workout", "description": "Add an inline planned workout to the training calendar from raw objects"},  # noqa: E501
-            {"name": "update_scheduled_workout", "description": "Update an existing scheduled workout on the calendar"},  # noqa: E501
-            {"name": "schedule_strength_workout", "description": "Schedule a one-off strength workout for a date (no library entry)"},  # noqa: E501
-            {"name": "schedule_workout_template", "description": "Schedule an existing library workout template on a specific date"},  # noqa: E501
-            {"name": "remove_scheduled_workout", "description": "Remove a workout from the training calendar"},
-            {"name": "list_exercises", "description": "List available strength exercises (used when building strength workouts)"},  # noqa: E501
-            {"name": "sync_coros_data", "description": "Backfill local cache from the Coros API for a date range"},
-            {"name": "get_cache_status", "description": "Show local cache coverage: date ranges stored for each data type"},  # noqa: E501
-        ]
+        "toolset": _TOOLSET,
+        "tools": [t for t in _TOOL_DESCRIPTIONS if t["name"] in _ENABLED_TOOLS],
     }
 
 
@@ -164,11 +234,11 @@ async def get_help() -> dict:
 # Tool: authenticate_coros
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(auth_tool=True, annotations=_WRITE)
 async def authenticate_coros(
     email: str,
     password: str,
-    region: str = "eu",
+    region: Literal["eu", "us"] = "eu",
 ) -> dict:
     """
     Authenticate with the Coros Training Hub API and store the access token.
@@ -206,11 +276,11 @@ async def authenticate_coros(
 # Tool: authenticate_coros_mobile
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(auth_tool=True, annotations=_WRITE)
 async def authenticate_coros_mobile(
     email: str,
     password: str,
-    region: str = "eu",
+    region: Literal["eu", "us"] = "eu",
 ) -> dict:
     """
     Authenticate with the Coros mobile API only and store the mobile token.
@@ -251,7 +321,7 @@ async def authenticate_coros_mobile(
 # Tool: check_coros_auth
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(annotations=_READ)
 async def check_coros_auth(verify_with_server: bool = False) -> dict:
     """
     Check whether valid Coros access tokens are stored locally.
@@ -338,8 +408,8 @@ async def _verify_web_token_status(auth: coros_api.StoredAuth) -> dict:
 # Tool: get_daily_metrics
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
-async def get_daily_metrics(weeks: int = 4) -> dict:
+@_tool(annotations=_READ)
+async def get_daily_metrics(weeks: _Weeks = 4) -> dict:
     """
     Retrieve nightly HRV and daily metrics from Coros for a configurable
     time range (up to 52 weeks).
@@ -404,8 +474,8 @@ async def get_daily_metrics(weeks: int = 4) -> dict:
 # Tool: get_sleep_data
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
-async def get_sleep_data(weeks: int = 4) -> dict:
+@_tool(annotations=_READ)
+async def get_sleep_data(weeks: _Weeks = 4) -> dict:
     """
     Fetch nightly sleep data from Coros for a configurable time range.
 
@@ -460,12 +530,12 @@ async def get_sleep_data(weeks: int = 4) -> dict:
 # Tool: list_activities
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(annotations=_READ)
 async def list_activities(
-    start_day: str,
-    end_day: str,
-    page: int = 1,
-    size: int = 30,
+    start_day: _Day,
+    end_day: _Day,
+    page: Annotated[int, Field(ge=1)] = 1,
+    size: Annotated[int, Field(ge=1, le=100)] = 30,
 ) -> dict:
     """
     List Coros activities for a date range.
@@ -586,7 +656,7 @@ def _compact_activity(data: dict) -> dict:
     return out
 
 
-@mcp.tool()
+@_tool(annotations=_READ)
 async def get_activity_detail(activity_id: str, sport_type: int = 0) -> dict:
     """
     Fetch detail for a single Coros activity.
@@ -621,7 +691,7 @@ async def get_activity_detail(activity_id: str, sport_type: int = 0) -> dict:
 # Tool: list_workout_templates
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(annotations=_READ)
 async def list_workout_templates() -> dict:
     """
     List reusable workout templates saved in the Coros library.
@@ -652,7 +722,7 @@ async def list_workout_templates() -> dict:
 # Tool: list_training_plans
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(annotations=_READ)
 async def list_training_plans(
     status_list: list[int] | None = None,
 ) -> dict:
@@ -684,7 +754,7 @@ async def list_training_plans(
 # Tool: list_training_plans_raw
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(advanced=True, annotations=_READ)
 async def list_training_plans_raw(
     status_list: list[int] | None = None,
 ) -> dict:
@@ -708,7 +778,7 @@ async def list_training_plans_raw(
 # Tool: save_workout_template
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, annotations=_WRITE)
 async def save_workout_template(
     name: str,
     steps: list[dict],
@@ -755,12 +825,12 @@ async def save_workout_template(
 
         Example:
         [
-            {"name": "Warm-up", "duration_minutes": 10, "intensity_low": 148, "intensity_high": 192},
+    {"name": "Warm-up", "duration_minutes": 10, "intensity_low": 148, "intensity_high": 192},
             {"repeat": 3, "steps": [
                 {"name": "Sweetspot", "duration_minutes": 10, "intensity_low": 265, "intensity_high": 285},
                 {"name": "Recovery", "duration_minutes": 3, "intensity_low": 150, "intensity_high": 175},
             ]},
-            {"name": "Cool-down", "duration_minutes": 10, "intensity_low": 100, "intensity_high": 165},
+    {"name": "Cool-down", "duration_minutes": 10, "intensity_low": 100, "intensity_high": 165},
         ]
 
     sport_type : int
@@ -805,7 +875,7 @@ async def save_workout_template(
 # Tool: delete_workout_template
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, annotations=_DESTRUCTIVE)
 async def delete_workout_template(
     workout_id: str,
 ) -> dict:
@@ -839,10 +909,10 @@ async def delete_workout_template(
 # Tool: list_planned_activities
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(annotations=_READ)
 async def list_planned_activities(
-    start_day: str,
-    end_day: str,
+    start_day: _Day,
+    end_day: _Day,
 ) -> dict:
     """
     List planned (scheduled) activities from the Coros training calendar.
@@ -877,10 +947,10 @@ async def list_planned_activities(
 # Tool: list_planned_activities_raw
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(advanced=True, annotations=_READ)
 async def list_planned_activities_raw(
-    start_day: str,
-    end_day: str,
+    start_day: _Day,
+    end_day: _Day,
 ) -> dict:
     """
     List planned activities without stripping API fields.
@@ -907,7 +977,7 @@ async def list_planned_activities_raw(
 # Tool: calculate_workout_program
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(advanced=True, annotations=_READ)
 async def calculate_workout_program(program: dict) -> dict:
     """
     Recalculate a workout program after editing its exercises.
@@ -933,10 +1003,10 @@ async def calculate_workout_program(program: dict) -> dict:
 # Tool: schedule_workout_template
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, annotations=_WRITE)
 async def schedule_workout_template(
     workout_id: str,
-    happen_day: str,
+    happen_day: _Day,
     sort_no: int = 1,
 ) -> dict:
     """
@@ -995,11 +1065,11 @@ async def schedule_workout_template(
 # Tool: schedule_workout (inline, one-off cycling/intervals)
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, annotations=_WRITE)
 async def schedule_workout(
     name: str,
     steps: list[dict],
-    happen_day: str,
+    happen_day: _Day,
     sport_type: int = 2,
     intensity_type: int | None = None,
     sort_no: int = 1,
@@ -1087,7 +1157,7 @@ async def schedule_workout(
 # Tool: add_planned_workout
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, advanced=True, annotations=_WRITE)
 async def add_planned_workout(
     entity: dict,
     program: dict,
@@ -1131,7 +1201,7 @@ async def add_planned_workout(
 # Tool: update_scheduled_workout
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, advanced=True, annotations=_DESTRUCTIVE)
 async def update_scheduled_workout(
     entity: dict,
     program: dict,
@@ -1177,11 +1247,11 @@ async def update_scheduled_workout(
 # Tool: schedule_strength_workout (inline, one-off strength)
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, annotations=_WRITE)
 async def schedule_strength_workout(
     name: str,
     exercises: list[dict],
-    happen_day: str,
+    happen_day: _Day,
     sets: int = 1,
     sort_no: int = 1,
 ) -> dict:
@@ -1262,7 +1332,7 @@ async def schedule_strength_workout(
 # Tool: remove_scheduled_workout
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, annotations=_DESTRUCTIVE)
 async def remove_scheduled_workout(
     plan_id: str,
     id_in_plan: str,
@@ -1300,7 +1370,7 @@ async def remove_scheduled_workout(
 # Tool: save_strength_workout_template
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(write=True, annotations=_WRITE)
 async def save_strength_workout_template(
     name: str,
     exercises: list[dict],
@@ -1383,7 +1453,7 @@ async def save_strength_workout_template(
 # Tool: list_exercises
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(annotations=_READ)
 async def list_exercises(sport_type: int = 4) -> dict:
     """
     List the exercise catalogue for a given sport type.
@@ -1414,8 +1484,8 @@ async def list_exercises(sport_type: int = 4) -> dict:
 # Tool: sync_coros_data
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
-async def sync_coros_data(start_day: str = "", end_day: str = "") -> dict:
+@_tool(annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True})
+async def sync_coros_data(start_day: _DayOrEmpty = "", end_day: _DayOrEmpty = "") -> dict:
     """
     Sync Coros data for a date range into the local SQLite cache.
 
@@ -1462,7 +1532,7 @@ async def sync_coros_data(start_day: str = "", end_day: str = "") -> dict:
 # Tool: get_cache_status
 # ---------------------------------------------------------------------------
 
-@mcp.tool()
+@_tool(annotations=_READ_LOCAL)
 async def get_cache_status() -> dict:
     """
     Show what data is currently stored in the local cache.

--- a/tests/test_toolset_gating.py
+++ b/tests/test_toolset_gating.py
@@ -1,0 +1,153 @@
+"""Tests for agent-hardening toolset gating (COROS_MCP_TOOLSET /
+COROS_MCP_HIDE_AUTH_TOOLS) and the stricter parameter schemas.
+
+The server module is reloaded per scenario because gating happens at import
+time (tool registration). A fixture restores the default full toolset
+afterwards so other test modules see the unmodified module.
+"""
+import asyncio
+import importlib
+
+import pytest
+
+import coros_mcp.server as server_mod
+
+WRITE_TOOLS = {
+    "save_workout_template",
+    "save_strength_workout_template",
+    "delete_workout_template",
+    "schedule_workout",
+    "schedule_strength_workout",
+    "schedule_workout_template",
+    "add_planned_workout",
+    "update_scheduled_workout",
+    "remove_scheduled_workout",
+}
+ADVANCED_TOOLS = {
+    "list_training_plans_raw",
+    "list_planned_activities_raw",
+    "calculate_workout_program",
+}
+AUTH_TOOLS = {"authenticate_coros", "authenticate_coros_mobile"}
+READONLY_TOOLS = {
+    "get_help",
+    "check_coros_auth",
+    "get_daily_metrics",
+    "get_sleep_data",
+    "list_activities",
+    "get_activity_detail",
+    "list_workout_templates",
+    "list_training_plans",
+    "list_planned_activities",
+    "list_exercises",
+    "sync_coros_data",
+    "get_cache_status",
+}
+ALL_TOOLS = READONLY_TOOLS | WRITE_TOOLS | ADVANCED_TOOLS | AUTH_TOOLS
+
+
+def _registered_tools(mod):
+    return {t.name for t in asyncio.run(mod.mcp.list_tools())}
+
+
+@pytest.fixture
+def reload_server(monkeypatch):
+    def _reload(toolset=None, hide_auth=None):
+        if toolset is None:
+            monkeypatch.delenv("COROS_MCP_TOOLSET", raising=False)
+        else:
+            monkeypatch.setenv("COROS_MCP_TOOLSET", toolset)
+        if hide_auth is None:
+            monkeypatch.delenv("COROS_MCP_HIDE_AUTH_TOOLS", raising=False)
+        else:
+            monkeypatch.setenv("COROS_MCP_HIDE_AUTH_TOOLS", hide_auth)
+        return importlib.reload(server_mod)
+
+    yield _reload
+    # Restore the default (full) toolset for subsequent test modules.
+    monkeypatch.delenv("COROS_MCP_TOOLSET", raising=False)
+    monkeypatch.delenv("COROS_MCP_HIDE_AUTH_TOOLS", raising=False)
+    importlib.reload(server_mod)
+
+
+def test_default_registers_all_tools(reload_server):
+    mod = reload_server()
+    assert _registered_tools(mod) == ALL_TOOLS
+
+
+def test_readonly_hides_write_advanced_and_auth_tools(reload_server):
+    mod = reload_server(toolset="readonly")
+    assert _registered_tools(mod) == READONLY_TOOLS
+
+
+def test_hide_auth_tools_only(reload_server):
+    mod = reload_server(hide_auth="1")
+    assert _registered_tools(mod) == ALL_TOOLS - AUTH_TOOLS
+
+
+def test_invalid_toolset_fails_fast(reload_server):
+    with pytest.raises(ValueError, match="COROS_MCP_TOOLSET"):
+        reload_server(toolset="readonyl")
+    # Leave the module importable again (reload with valid env happens in
+    # fixture teardown, but the failed reload leaves a broken module object
+    # behind — restore immediately so later asserts in THIS test could run).
+
+
+def test_hidden_tools_stay_plain_callables(reload_server):
+    mod = reload_server(toolset="readonly")
+    # Not registered over MCP, but still importable/callable for tests.
+    assert callable(mod.save_workout_template)
+    assert callable(mod.authenticate_coros)
+
+
+def test_get_help_lists_only_enabled_tools(reload_server):
+    mod = reload_server(toolset="readonly")
+    out = asyncio.run(mod.get_help())
+    assert out["toolset"] == "readonly"
+    assert {t["name"] for t in out["tools"]} == READONLY_TOOLS
+
+    mod = reload_server()
+    out = asyncio.run(mod.get_help())
+    assert out["toolset"] == "full"
+    assert {t["name"] for t in out["tools"]} == ALL_TOOLS
+
+
+def test_write_tools_carry_destructive_annotations(reload_server):
+    mod = reload_server()
+    tools = {t.name: t for t in asyncio.run(mod.mcp.list_tools())}
+    assert tools["get_daily_metrics"].annotations.readOnlyHint is True
+    assert tools["delete_workout_template"].annotations.destructiveHint is True
+    assert tools["remove_scheduled_workout"].annotations.destructiveHint is True
+    assert tools["schedule_workout"].annotations.readOnlyHint is False
+    assert tools["schedule_workout"].annotations.destructiveHint is False
+
+
+def test_schema_constraints_present(reload_server):
+    mod = reload_server()
+    tools = {t.name: t for t in asyncio.run(mod.mcp.list_tools())}
+    weeks = tools["get_daily_metrics"].parameters["properties"]["weeks"]
+    assert weeks["minimum"] == 1 and weeks["maximum"] == 52
+    start_day = tools["list_activities"].parameters["properties"]["start_day"]
+    assert start_day["pattern"] == r"^\d{8}$"
+    region = tools["authenticate_coros"].parameters["properties"]["region"]
+    assert set(region["enum"]) == {"eu", "us"}
+    sync_day = tools["sync_coros_data"].parameters["properties"]["start_day"]
+    assert sync_day["pattern"] == r"^(\d{8})?$"
+
+
+def test_mcp_layer_rejects_malformed_date(reload_server):
+    """An ISO date like 2025-03-16 must be rejected before any API call."""
+    from fastmcp import Client
+    from fastmcp.exceptions import ToolError
+
+    mod = reload_server()
+
+    async def _call():
+        async with Client(mod.mcp) as client:
+            await client.call_tool(
+                "list_activities",
+                {"start_day": "2025-03-16", "end_day": "20250320"},
+            )
+
+    with pytest.raises(ToolError):
+        asyncio.run(_call())


### PR DESCRIPTION
## Motivation

Running this server behind an autonomous agent framework (e.g. [hermes-agent](https://github.com/NousResearch/hermes-agent) with a smaller open-weight model) needs a harder surface than an interactive Claude session: fewer tools, no credential-carrying tools, and argument validation that fails loudly before an API call.

## Changes

- **`COROS_MCP_TOOLSET=readonly`** — registers only the 12 read tools; hides all account-write tools (save/schedule/update/delete), the raw escape hatches (`*_raw`, `add_planned_workout`, `update_scheduled_workout`, `calculate_workout_program`), and the auth tools. Default `full` keeps all 26 tools (backward compatible). Invalid values fail fast at startup.
- **`COROS_MCP_HIDE_AUTH_TOOLS=1`** — hides `authenticate_coros` / `authenticate_coros_mobile` in full mode so the account password can never travel through the model context or agent logs; auth then happens exclusively via `COROS_EMAIL`/`COROS_PASSWORD` auto-login or pre-stored tokens.
- **MCP tool annotations** — every tool now carries `readOnlyHint` / `destructiveHint` / `openWorldHint`, so harnesses that honor them can gate write actions behind confirmation.
- **Strict parameter schemas** — validated at the MCP layer instead of silently clamped or passed through: `YYYYMMDD` regex on all date params, `weeks` bounded 1–52, `page`/`size` bounds, `region` as `eu|us` enum.
- **`get_help`** — lists only actually registered tools and reports the active `toolset`.

Hidden tools remain plain importable Python functions (tests and library users are unaffected). Docs added to README (Step 4: agent hardening) and CLAUDE.md.

## Behavior changes (invalid inputs only)

- `weeks=104` is now rejected with a validation error instead of silently clamped to 52.
- Malformed dates (`"2025-03-16"`) are rejected before any API call.
- `get_help` gains a `toolset` field.

## Testing

- New `tests/test_toolset_gating.py` (9 tests): default/full registration, readonly set, auth-hiding, fail-fast on invalid value, importability of hidden tools, `get_help` filtering, annotations, schema constraints, and an in-memory `fastmcp.Client` call proving a malformed date is rejected at the protocol layer.
- Full suite: 198 passed; `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)