### PR TITLE
Document server-side normalization of pure-distance group headers

### DIFF
--- a/coros_mcp/coros_api.py
+++ b/coros_mcp/coros_api.py
@@ -960,6 +960,12 @@ def _build_workout_program_payload(
                 "sportType": wire_sport_type,
                 "intensityType": 0,
                 "intensityValue": 0,
+                # Always sent time-typed; for pure-distance groups this means
+                # targetValue=0, which the server accepts and normalizes to a
+                # distance header itself (targetType=5, targetValue = one
+                # iteration's meters x100) with correct derived distance/
+                # duration/load. Verified live 2026-08-12 by scheduling a
+                # 3x400m distance-only group and reading back the raw values.
                 "targetType": 2,
                 "targetValue": iteration_seconds,
                 "sets": step["repeat"],


### PR DESCRIPTION
Closes the last open point (⚠️ 4) from the Hermes Agent review on #52 — live verification showed the Coros server accepts a pure-distance repeat group and normalizes the time-typed header to a distance header itself (details in the code comment and in the #52 comment thread). Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)