### PR TITLE
Fix corrupted CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-žée
 * @cygnusb


### PR DESCRIPTION
Removes stray garbage bytes accidentally written before the CODEOWNERS entry.